### PR TITLE
Change error handling in Simulation, SimBuilder

### DIFF
--- a/src/ecs/examples/proposed_usage.rs
+++ b/src/ecs/examples/proposed_usage.rs
@@ -24,9 +24,13 @@ struct Position {
 fn main () {
     let mut world = ecs::World::new();
 
-    let (mut sim, _errs) = ecs::Simulation::build()
+    let sim_builder_result = ecs::Simulation::build()
                                            .with(Rendering)
                                            .done();
+    let mut sim = match  sim_builder_result {
+        Err(e) => panic!("Simulation couldn't be built due to: {:?}", e),
+        Ok(sim) => sim
+    };
 
     let ent = world.create_entity();
     world.insert_component(ent, Position { x: 0.0, y: 0.0, z: 0.0 });

--- a/src/ecs/src/lib.rs
+++ b/src/ecs/src/lib.rs
@@ -5,6 +5,6 @@ mod sim;
 mod world;
 
 pub use self::entity::Entity;
-pub use self::processor::{Processor, ProcessorError};
+pub use self::processor::{Processor, ProccessorResult};
 pub use self::sim::{Simulation, SimBuilder};
 pub use self::world::World;

--- a/src/ecs/src/processor.rs
+++ b/src/ecs/src/processor.rs
@@ -1,14 +1,15 @@
 //! Performs actions based on the relevant components found in the game world.
 
-/// The error type reported by processors if they fail to initialize.
-/// TODO: Implement actual error handling either with Result or custom
-/// type alias.
-pub struct ProcessorError;
+/// The error type reported by SimBuilder if they fail to initialize.
+/// TODO: original note specified it was en error type reported by a **processor**,
+/// although, as seen below, Processor doesn't have any function to return an error,
+/// thus, only SimBuilder can return Result as of now.
+pub type ProccessorResult = Result<(), String>;
 
 /// The trait implemented by all processors.
 pub trait Processor {
     /// TODO: Need to finalize API design here, according to [issue #10].
-    /// 
+    ///
     /// [issue #10]: https://github.com/ebkalderon/amethyst/issues/10
     fn process(&mut self);
 }


### PR DESCRIPTION
Changed error handling to more 'Rusty' way with Results:
- Introduced `pub type ProccessorResult = Result<(), String>;` instead of ProcessorError
- SimBuilder collects all errors, while building
- Simbuilder's `done` returns `Result<Simulation, Vec<String>`, where
  - `Ok` is returned if no errors met
  - `Err` is returned if at least one error happened

Should be noted (and is noted in processor.rs), that original note for ProccessorError specified it was an error type reported by a **processor**, although, currently, Processor doesn't have any way to return an error, thus, only SimBuilder can return Result as of now.