### PR TITLE
Update links in preparation for repo transfer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,12 @@ adheres to [Semantic Versioning][sv].
 * Depend on gfx-rs to reduce workload and foster cooperation, removed old
   renderer backend code
 
-[#9]: https://github.com/ebkalderon/amethyst/issues/9
-[#11]: https://github.com/ebkalderon/amethyst/issues/11
-[#12]: https://github.com/ebkalderon/amethyst/issues/12
-[#13]: https://github.com/ebkalderon/amethyst/issues/13
-[#14]: https://github.com/ebkalderon/amethyst/issues/14
-[#15]: https://github.com/ebkalderon/amethyst/issues/15
+[#9]: https://github.com/amethyst/amethyst/issues/9
+[#11]: https://github.com/amethyst/amethyst/issues/11
+[#12]: https://github.com/amethyst/amethyst/issues/12
+[#13]: https://github.com/amethyst/amethyst/issues/13
+[#14]: https://github.com/amethyst/amethyst/issues/14
+[#15]: https://github.com/amethyst/amethyst/issues/15
 
 ## 0.1.4 (2016-01-10)
 
@@ -43,12 +43,12 @@ adheres to [Semantic Versioning][sv].
 * Remove standardized `State` constructor (pull request [#6])
 * Update book and doc comments
 
-[#6]: https://github.com/ebkalderon/amethyst/issues/6
+[#6]: https://github.com/amethyst/amethyst/issues/6
 
 ### Fixed
 * Fix unreachable shutdown statement bug (issue [#5])
 
-[#5]: https://github.com/ebkalderon/amethyst/issues/5
+[#5]: https://github.com/amethyst/amethyst/issues/5
 
 ## 0.1.3 (2016-01-09)
 
@@ -67,7 +67,7 @@ adheres to [Semantic Versioning][sv].
   * Backend
     * Consolidate traits into one short file
 
-[#7]: https://github.com/ebkalderon/amethyst/issues/7
+[#7]: https://github.com/amethyst/amethyst/issues/7
 
 ## 0.1.1 (2016-01-06)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,11 +15,11 @@ GitHub issue trackers. We can't fix problems we don't know about, so please
 report early and often! Make sure to post your issue on the tracker most
 relevant to you:
 
-* [Amethyst Tracker][am]: Issues on the game engine itself or the Amethyst Book.
-* [Amethyst Tools Tracker][at]: Issues on the toolchain surrounding the engine.
+* [Engine Tracker][et]: Issues on the game engine itself or the Amethyst Book.
+* [Tools Tracker][tt]: Issues on the toolchain surrounding the engine.
 
-[am]: https://github.com/ebkalderon/amethyst/issues
-[at]: https://github.com/ebkalderon/amethyst_tools/issues
+[et]: https://github.com/amethyst/amethyst/issues
+[tt]: https://github.com/amethyst/tools/issues
 
 Before posting your issue, please take a moment to search the tracker's existing
 issues first, as it's possible that someone else reported the same issue before
@@ -88,19 +88,19 @@ have done the following things first:
    * `cargo test`
    * `cargo run` (if it's a binary)
 
-[ml]: https://github.com/ebkalderon/amethyst/blob/master/COPYING
-[ti]: https://github.com/ebkalderon/amethyst/blob/master/src/engine/src/timing.rs#L68-L112
+[ml]: ./COPYING
+[ti]: ./src/engine/src/timing.rs#L68-L112
 
 > If you want to be publicly known as an author, feel free to add your name
 > and/or GitHub username to the AUTHORS.md file in your pull request.
 
 Once you have pushed your pull request to the repository, please wait for a
 reviewer to give feedback on it. If no one responds, feel free to @-mention a
-developer or post publicly on [the Gitter chat room][gi] asking for a review.
-Once your code has been reviewed, revised if necessary, and then signed-off by a
-developer, it will be merged into the source tree.
+developer or post publicly on [the `engine` room on Gitter][gi] asking for a
+review. Once your code has been reviewed, revised if necessary, and then
+signed-off by a developer, it will be merged into the source tree.
 
-[gi]: https://gitter.im/ebkalderon/amethyst
+[gi]: https://gitter.im/amethyst/engine
 
 Thank you so much for your contribution! Now Amethyst will be a little bit
 faster, stronger, and more efficient.
@@ -117,8 +117,8 @@ There are two types of documentation in Amethyst you can work on:
 1. [API documentation][ad]
 2. [The online Amethyst book][ab]
 
-[ad]: http://ebkalderon.github.io/amethyst/doc/amethyst/
-[ab]: http://ebkalderon.github.io/amethyst/
+[ad]: https://www.amethyst.rs/doc/amethyst/
+[ab]: https://www.amethyst.rs/book/
 
 Our Rust API documentation is generated directly from source code comments
 marked with either `///` or `//!` using  a tool called Rustdoc. See
@@ -133,7 +133,7 @@ The Amethyst book is generated using a different documentation tool called
 [book/src/][bk] directory of the Amethyst repository.
 
 [mb]: https://github.com/azerupi/mdBook
-[bk]: https://github.com/ebkalderon/amethyst/tree/master/book/src
+[bk]: ./book/src
 
 Documentation of any kind should adhere to the following standard:
 
@@ -173,7 +173,7 @@ in the [Pull Requests](#pull-requests) section above.
     code samples.
   * [The Rust Programming Language][rl] - The canonical online book about Rust.
 
-[dr]: https://github.com/ebkalderon/amethyst/wiki/Roadmap
+[dr]: https://github.com/amethyst/amethyst/wiki/Roadmap
 
 [bs]: https://www.kth.se/social/upload/5289cb3ff276542440dd668c/bitsquid-behind-the-scenes.pdf
 [fr]: http://twvideo01.ubm-us.net/o1/vault/gdc2012/slides/Programming%20Track/Persson_Tobias_Flexible_Rendering.pdf.pdf

--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 [s1]: https://travis-ci.org/ebkalderon/amethyst.svg?branch=master
 [s2]: https://img.shields.io/badge/crates.io-0.2.1-orange.svg
 [s3]: https://img.shields.io/badge/license-MIT-blue.svg
-[s4]: https://badges.gitter.im/ebkalderon/amethyst.svg
+[s4]: https://badges.gitter.im/amethyst/general.svg
 
 [tc]: https://travis-ci.org/ebkalderon/amethyst/
 [ci]: https://crates.io/crates/amethyst/
-[ml]: https://github.com/ebkalderon/amethyst/blob/master/COPYING
-[gc]: https://gitter.im/ebkalderon/amethyst?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[ml]: https://github.com/amethyst/amethyst/blob/master/COPYING
+[gc]: https://gitter.im/orgs/amethyst/rooms
 
 This project is a *work in progress* and is very incomplete; pardon the dust!
 Read a summary of what happened this past week at [*This Week in Amethyst*][tw].
@@ -54,7 +54,7 @@ does not aim to be API-compatible with it in any way. Some goals include:
 [mr]: http://mruby.org/
 [lu]: http://www.lua.org/
 [pi]: http://www.piston.rs/
-[at]: https://github.com/ebkalderon/amethyst_tools
+[at]: https://github.com/amethyst/tools
 [up]: https://en.wikipedia.org/wiki/Unix_philosophy
 
 ## Usage
@@ -62,8 +62,8 @@ does not aim to be API-compatible with it in any way. Some goals include:
 Read the [online book][bk] for a comprehensive tutorial to using Amethyst. There
 is also an online crate-level [API reference][ar].
 
-[bk]: http://ebkalderon.github.io/amethyst/
-[ar]: http://ebkalderon.github.io/amethyst/doc/amethyst/
+[bk]: https://www.amethyst.rs/book/
+[ar]: https://www.amethyst.rs/doc/amethyst/
 
 ## Quick Example
 
@@ -71,8 +71,8 @@ See the [Getting Started][gs] chapter in the book for the full-blown "Hello,
 World!" tutorial. For the sake of brevity, you can generate an empty game
 project with the [Amethyst CLI tool][ac] and build it. Follow along below:
 
-[gs]: http://ebkalderon.github.io/amethyst/getting_started.html
-[ac]: https://github.com/ebkalderon/amethyst_tools/tree/master/src/cli
+[gs]: https://www.amethyst.rs/book/getting_started.html
+[ac]: https://github.com/amethyst/tools/tree/master/src/cli
 
 ```
 $ cargo install amethyst_tools
@@ -114,6 +114,6 @@ interested in helping out, please read the [CONTRIBUTING.md][cm] file before
 getting started. Don't know what to hack on? See the
 [Development Roadmap][dr] on our wiki, or search though [our issue tracker][it].
 
-[cm]: ./CONTRIBUTING.md
-[dr]: https://github.com/ebkalderon/amethyst/wiki/Roadmap
-[it]: https://github.com/ebkalderon/amethyst/issues
+[cm]: https://github.com/amethyst/amethyst/blob/master/CONTRIBUTING.md
+[dr]: https://github.com/amethyst/amethyst/wiki/Roadmap
+[it]: https://github.com/amethyst/amethyst/issues

--- a/book/src/getting_started.md
+++ b/book/src/getting_started.md
@@ -34,5 +34,5 @@ Since we're just getting started, it's fastest and highly recommended to use
 [Amethyst CLI][ac], which is included in the [amethyst_tools][at] crate. If
 you're of the intrepid type, you may go the vanilla Cargo route if you wish.
 
-[ac]: https://github.com/ebkalderon/amethyst_tools/tree/master/src/cli
-[at]: https://github.com/ebkalderon/amethyst_tools
+[ac]: https://github.com/amethyst/tools/tree/master/src/cli
+[at]: https://github.com/amethyst/tools

--- a/book/src/getting_started/automatic_setup.md
+++ b/book/src/getting_started/automatic_setup.md
@@ -4,7 +4,7 @@ An easy way to set up Amethyst and manage your project is with the
 [amethyst_tools][at] crate. If you want to set up a game project in Cargo by
 hand, follow along with [the next section][ci] instead.
 
-[at]: https://github.com/ebkalderon/amethyst_tools
+[at]: https://github.com/amethyst/tools
 [ci]: ./getting_started/manual_cargo_setup.html
 
 To install the toolchain and generate a new project with the CLI tool, follow

--- a/book/src/intro.md
+++ b/book/src/intro.md
@@ -19,8 +19,8 @@ Amethyst is free and open source software, distributed under the
 source code is completely yours to tinker with. The code is available on
 [GitHub][am]. Contributions and feature requests are welcome!
 
-[ml]: https://github.com/ebkalderon/amethyst/blob/master/COPYING
-[am]: https://github.com/ebkalderon/amethyst
+[ml]: https://github.com/amethyst/amethyst/blob/master/COPYING
+[am]: https://github.com/amethyst/amethyst
 
 This book is split into seven sections. This page is the first. The others are:
 
@@ -38,7 +38,7 @@ This book is split into seven sections. This page is the first. The others are:
 
 Read the crate-level [API documentation][ad] for more details.
 
-[ad]: http://ebkalderon.github.io/amethyst/doc/amethyst/
+[ad]: https://www.amethyst.rs/doc/amethyst/
 
 ## Why are you building this?
 
@@ -80,4 +80,4 @@ In short, I am writing Amethyst to scratch three of my own itches:
 The Markdown source files from which this book is generated can be found
 [on GitHub][md]. Pull requests are welcome!
 
-[md]: https://github.com/ebkalderon/amethyst/tree/master/book/src
+[md]: https://github.com/amethyst/amethyst/tree/master/book/src

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 #![crate_name = "amethyst"]
 #![crate_type = "lib"]
-#![doc(html_logo_url = "http://tinyurl.com/hgsb45k")]
+#![doc(html_logo_url = "http://tinyurl.com/jtmm43a")]
 
 //! Amethyst is a free and open source game engine written in idiomatic
 //! [Rust][rs] for building video games and interactive multimedia applications.
@@ -8,8 +8,8 @@
 //! [online book][bk] for a complete guide to using Amethyst.
 //!
 //! [rs]: https://www.rust-lang.org/
-//! [gh]: https://github.com/ebkalderon/amethyst
-//! [bk]: http://ebkalderon.github.io/amethyst/
+//! [gh]: https://github.com/amethyst/amethyst
+//! [bk]: https://www.amethyst.rs/
 //!
 //! This project is a work in progress and is very incomplete. Pardon the dust!
 //!

--- a/src/renderer/README.md
+++ b/src/renderer/README.md
@@ -5,12 +5,12 @@
 [s1]: https://api.travis-ci.org/ebkalderon/amethyst.svg
 [s2]: https://img.shields.io/badge/crates.io-0.2.1-orange.svg
 [s3]: https://img.shields.io/badge/license-MIT-blue.svg
-[s4]: https://badges.gitter.im/ebkalderon/amethyst.svg
+[s4]: https://badges.gitter.im/amethyst/amethyst.svg
 
 [tc]: https://travis-ci.org/ebkalderon/amethyst/
 [ci]: https://crates.io/crates/amethyst_renderer/
-[ml]: https://github.com/ebkalderon/amethyst/blob/master/COPYING
-[gc]: https://gitter.im/ebkalderon/amethyst?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+[ml]: https://github.com/amethyst/amethyst/blob/master/COPYING
+[gc]: https://gitter.im/org/amethyst/rooms
 
 High-level rendering engine with multiple backends. This project is a *work in
 progress* and is very incomplete. Pardon the dust!


### PR DESCRIPTION
New repository location will be https://github.com/amethyst/amethyst. Still need to take care of old wiki and *TWIA* links.