### PR TITLE
Rendering stuff

### DIFF
--- a/amethyst_renderer/examples/material.rs
+++ b/amethyst_renderer/examples/material.rs
@@ -1,0 +1,109 @@
+//! Launches a new renderer window.
+
+extern crate amethyst_renderer as renderer;
+extern crate genmesh;
+extern crate winit;
+extern crate glutin;
+extern crate cgmath;
+
+use cgmath::{Matrix4, Deg, Vector3};
+use cgmath::prelude::{InnerSpace, Transform};
+use genmesh::{MapToVertices, Triangulate, Vertices};
+use genmesh::generators::SphereUV;
+use glutin::EventsLoop;
+use renderer::prelude::*;
+use renderer::vertex::PosNormTex;
+use std::time::{Duration, Instant};
+use winit::ElementState::Pressed;
+use winit::{Event, WindowEvent};
+use winit::VirtualKeyCode as Key;
+
+fn main() {
+    let events = EventsLoop::new();
+    let mut renderer = Renderer::new(&events).expect("Renderer create");
+    let pipe = renderer.create_pipe(
+        Pipeline::forward()
+            .with_stage(
+                Stage::with_backbuffer()
+                    .with_pass(pass::ClearTarget::with_values([0.02, 0.02, 0.02, 1.0], Some(2.0)))
+                    // .with_pass(&pass::DrawFlat::<PosNormTex>::new())
+                    .with_pass(&pass::DrawShaded::<PosNormTex>::new())
+            )
+    ).expect("Pipeline create");
+
+    let verts = gen_sphere(64, 64);
+    let mesh = renderer.create_mesh(Mesh::build(&verts)).expect("Mesh create");
+
+    // let bytes = load_texture("bricks.png").unwrap();
+    // let tex = renderer.create_texture(Texture::build(&bytes)).unwrap();
+
+    let mut scene = Scene::default();
+
+    for i in 0..5 {
+        for j in 0..5 {
+            let roughness = (1.0f32 * (i as f32 / 4.0f32));
+            let metallic = (1.0f32 * (j as f32 / 4.0f32));
+            let pos = Matrix4::from_translation([2.0f32 * (i - 2) as f32, 2.0f32 * (j - 2) as f32, 0.0].into()) * Matrix4::from_scale(0.8);
+
+            let alb = renderer.create_texture(Texture::from_color_val([1.0; 4])).expect("Texture create");
+            let rog = renderer.create_texture(Texture::from_color_val([roughness; 4])).expect("Texture create");
+            let met = renderer.create_texture(Texture::from_color_val([metallic; 4])).expect("Texture create");
+            let mtl = renderer.create_material(MaterialBuilder::new().with_albedo(&alb).with_roughness(&rog).with_metallic(&met)).expect("Material create");
+            let model = Model { mesh: mesh.clone(), material: mtl, pos: pos };
+            scene.add_model(model);
+        }
+    }
+
+    let light = PointLight {
+        center: [6.0, 6.0, -6.0].into(),
+        intensity: 6.0,
+        color: [0.8, 0.0, 0.0].into(),
+        ..PointLight::default()
+    };
+    scene.add_light(light);
+
+    let light = PointLight {
+        center: [6.0, -6.0, -6.0].into(),
+        intensity: 5.0,
+        color: [0.0, 0.3, 0.7].into(),
+        ..PointLight::default()
+    };
+    scene.add_light(light);
+
+    scene.add_camera(Camera {
+        eye: [0.0, 0.0, -12.0].into(),
+        proj: Projection::perspective(1.3, Deg(60.0)).into(),
+        forward: [0.0, 0.0, 1.0].into(),
+        right: [1.0, 0.0, 0.0].into(),
+        up: [0.0, 1.0, 0.0].into(),
+    });
+
+    let mut delta = Duration::from_secs(0);
+    events.run_forever(|e| {
+        let start = Instant::now();
+
+        let Event::WindowEvent { event, .. } = e;
+        match event {
+            WindowEvent::KeyboardInput(Pressed, _, Some(Key::Escape), _) |
+            WindowEvent::Closed => events.interrupt(),
+            _ => (),
+        }
+
+        renderer.draw(&scene, &pipe, delta);
+        delta = Instant::now() - start;
+    });
+}
+
+fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTex> {
+    SphereUV::new(u, v)
+        .vertex(|(x, y, z)| {
+            PosNormTex {
+                a_position: [x, y, z],
+                a_normal: Vector3::from([x, y, z]).normalize().into(),
+                a_tex_coord: [0.1, 0.1],
+            }
+        })
+        .triangulate()
+        .vertices()
+        .collect()
+}

--- a/amethyst_renderer/examples/sphere.rs
+++ b/amethyst_renderer/examples/sphere.rs
@@ -4,12 +4,15 @@ extern crate amethyst_renderer as renderer;
 extern crate genmesh;
 extern crate winit;
 extern crate glutin;
+extern crate cgmath;
 
+use cgmath::{Matrix4, Deg, Vector3};
+use cgmath::prelude::{InnerSpace, Transform};
 use genmesh::{MapToVertices, Triangulate, Vertices};
 use genmesh::generators::SphereUV;
 use glutin::EventsLoop;
 use renderer::prelude::*;
-use renderer::vertex::PosColor;
+use renderer::vertex::PosNormTex;
 use std::time::{Duration, Instant};
 use winit::ElementState::Pressed;
 use winit::{Event, WindowEvent};
@@ -17,20 +20,35 @@ use winit::VirtualKeyCode as Key;
 
 fn main() {
     let events = EventsLoop::new();
-    let mut renderer = Renderer::new(&events).unwrap();
-    let pipe = renderer.create_pipe(Pipeline::forward()).unwrap();
+    let mut renderer = Renderer::new(&events).expect("Renderer create");
+    let pipe = renderer.create_pipe(
+        Pipeline::forward()
+            .with_stage(
+                Stage::with_backbuffer()
+                    .with_pass(pass::ClearTarget::with_values([0.00196, 0.23726, 0.21765, 1.0], None))
+                    .with_pass(&pass::DrawFlat::<PosNormTex>::new())
+            )
+    ).expect("Pipeline create");
 
     let verts = gen_sphere(32, 32);
-    let mesh = renderer.create_mesh(Mesh::build(&verts)).unwrap();
+    let mesh = renderer.create_mesh(Mesh::build(&verts)).expect("Mesh create");
 
     // let bytes = load_texture("bricks.png").unwrap();
     // let tex = renderer.create_texture(Texture::build(&bytes)).unwrap();
-    // let mtl = Material::build().with_albedo(&tex).finish();
-    // let model = Model { mesh: mesh, material: mtl };
+    let tex = renderer.create_texture(Texture::from_color_val([0.88235, 0.09412, 0.21569, 1.0])).expect("Texture create");
+    let mtl = renderer.create_material(MaterialBuilder::new().with_albedo(&tex)).expect("Material create");
+    let model = Model { mesh: mesh, material: mtl, pos: Matrix4::one() };
 
     let mut scene = Scene::default();
-    // scene.add_model(&model);
+    scene.add_model(model);
     scene.add_light(PointLight::default());
+    scene.add_camera(Camera {
+        eye: [0.0, 0.0, -4.0].into(),
+        proj: Projection::perspective(1.3, Deg(60.0)).into(),
+        forward: [-0.1, 0.0, 1.0].into(),
+        right: [1.0, 0.0, 0.0].into(),
+        up: [0.0, 1.0, 0.0].into(),
+    });
 
     let mut delta = Duration::from_secs(0);
     events.run_forever(|e| {
@@ -48,12 +66,13 @@ fn main() {
     });
 }
 
-fn gen_sphere(u: usize, v: usize) -> Vec<PosColor> {
+fn gen_sphere(u: usize, v: usize) -> Vec<PosNormTex> {
     SphereUV::new(u, v)
         .vertex(|(x, y, z)| {
-            PosColor {
+            PosNormTex {
                 a_position: [x, y, z],
-                a_color: [0.5, 1.0, 0.0, 1.0],
+                a_normal: Vector3::from([x, y, z]).normalize().into(),
+                a_tex_coord: [0.1, 0.1],
             }
         })
         .triangulate()

--- a/amethyst_renderer/examples/sphere.rs
+++ b/amethyst_renderer/examples/sphere.rs
@@ -25,7 +25,7 @@ fn main() {
         Pipeline::forward()
             .with_stage(
                 Stage::with_backbuffer()
-                    .with_pass(pass::ClearTarget::with_values([0.00196, 0.23726, 0.21765, 1.0], None))
+                    .with_pass(pass::ClearTarget::with_values([0.00196, 0.23726, 0.21765, 1.0], Some(1.0f32)))
                     .with_pass(&pass::DrawFlat::<PosNormTex>::new())
             )
     ).expect("Pipeline create");
@@ -33,7 +33,7 @@ fn main() {
     let verts = gen_sphere(32, 32);
     let mesh = renderer.create_mesh(Mesh::build(&verts)).expect("Mesh create");
 
-    // let bytes = load_texture("bricks.png").unwrap();
+   // let bytes = load_texture("bricks.png").unwrap();
     // let tex = renderer.create_texture(Texture::build(&bytes)).unwrap();
     let tex = renderer.create_texture(Texture::from_color_val([0.88235, 0.09412, 0.21569, 1.0])).expect("Texture create");
     let mtl = renderer.create_material(MaterialBuilder::new().with_albedo(&tex)).expect("Material create");

--- a/amethyst_renderer/src/cam.rs
+++ b/amethyst_renderer/src/cam.rs
@@ -41,6 +41,15 @@ impl Projection {
     }
 }
 
+impl From<Projection> for Matrix4<f32> {
+    fn from(proj: Projection) -> Self {
+        match proj {
+            Projection::Orthographic(ortho) => ortho.into(),
+            Projection::Perspective(perspective) => perspective.into(),
+        }
+    }
+}
+
 /// Camera struct.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct Camera {

--- a/amethyst_renderer/src/lib.rs
+++ b/amethyst_renderer/src/lib.rs
@@ -160,7 +160,7 @@ impl Renderer {
 
         for stage in pipe.stages() {
             if stage.is_enabled() {
-                // stage.apply_func(self.encoders.first_mut().unwrap());
+                stage.apply_prep(self.encoders.first_mut().unwrap());
                 {
                     let encoders = self.encoders.as_mut_slice();
                     let encoders_count = encoders.len();
@@ -169,10 +169,10 @@ impl Renderer {
                         let mut mod_par_iter = scene.par_chunks_models(encoders_count);
                         assert!(enc_par_iter.len() >= mod_par_iter.len());
                         enc_par_iter.zip(mod_par_iter)
-                            .for_each(|(enc, models)| for model in models { stage.apply(enc, model, scene) });
+                            .for_each(|(enc, models)| for model in models { stage.apply_main(enc, scene, model) });
                     });
                 }
-                // stage.apply_post(self.encoders.last_mut().unwrap(), scene);
+                stage.apply_post(self.encoders.last_mut().unwrap(), scene);
                 for enc in self.encoders.iter_mut() {
                     enc.flush(&mut self.device);
                 }

--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -83,7 +83,7 @@ impl Default for PointLight {
         PointLight {
             center: Point3::new(0.0, 0.0, 0.0),
             color: Rgba::default(),
-            intensity: 100.0,
+            intensity: 10.0,
             radius: 10.0,
             smoothness: 4.0,
         }

--- a/amethyst_renderer/src/light.rs
+++ b/amethyst_renderer/src/light.rs
@@ -83,7 +83,7 @@ impl Default for PointLight {
         PointLight {
             center: Point3::new(0.0, 0.0, 0.0),
             color: Rgba::default(),
-            intensity: 10.0,
+            intensity: 100.0,
             radius: 10.0,
             smoothness: 4.0,
         }

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -124,7 +124,7 @@ impl<'v> MeshBuilder<'v> {
         let vbuf = fac.create_buffer_immutable_raw(verts, stride, role, bind)?;
         let slice = Slice {
             start: 0,
-            end: verts.len() as u32,
+            end: (verts.len() / stride) as u32,
             base_vertex: 0,
             instances: None,
             buffer: IndexBuffer::Auto,

--- a/amethyst_renderer/src/mesh.rs
+++ b/amethyst_renderer/src/mesh.rs
@@ -59,7 +59,7 @@ impl<'v> MeshBuilder<'v> {
         use gfx::memory::cast_slice;
 
         MeshBuilder {
-            attrs: V::attributes(),
+            attrs: V::attributes().as_ref().to_vec(),
             prim: Primitive::TriangleList,
             stride: V::size(),
             transform: Matrix4::identity(),

--- a/amethyst_renderer/src/mtl/mod.rs
+++ b/amethyst_renderer/src/mtl/mod.rs
@@ -52,7 +52,7 @@ impl MaterialBuilder {
     /// Creates a new material builder.
     pub fn new() -> Self {
         MaterialBuilder {
-            albedo: TextureKind::Constant([0.0, 0.0, 0.0, 1.0].into()),
+            albedo: TextureKind::Constant([0.0, 0.0, 0.5, 1.0].into()),
             emission: TextureKind::Constant([0.0; 4].into()),
             metallic: TextureKind::Constant([0.0; 4].into()),
             normal: TextureKind::Constant([0.0, 0.0, 1.0, 1.0].into()),

--- a/amethyst_renderer/src/mtl/mod.rs
+++ b/amethyst_renderer/src/mtl/mod.rs
@@ -16,10 +16,12 @@ pub struct Material {
     pub normal: Texture,
     /// Metallic map.
     pub metallic: Texture,
-    /// Reflectance map.
-    pub reflectance: Texture,
     /// Roughness map.
     pub roughness: Texture,
+    /// Ambient occlusion map.
+    pub ambient_occlusion: Texture,
+    /// Caveat map.
+    pub caveat: Texture,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -42,10 +44,11 @@ impl TextureKind {
 pub struct MaterialBuilder {
     albedo: TextureKind,
     emission: TextureKind,
-    metallic: TextureKind,
     normal: TextureKind,
-    reflectance: TextureKind,
+    metallic: TextureKind,
     roughness: TextureKind,
+    ambient_occlusion: TextureKind,
+    caveat: TextureKind,
 }
 
 impl MaterialBuilder {
@@ -56,8 +59,9 @@ impl MaterialBuilder {
             emission: TextureKind::Constant([0.0; 4].into()),
             metallic: TextureKind::Constant([0.0; 4].into()),
             normal: TextureKind::Constant([0.0, 0.0, 1.0, 1.0].into()),
-            reflectance: TextureKind::Constant([0.0; 4].into()),
-            roughness: TextureKind::Constant([0.5, 0.5, 0.5, 0.5].into()),
+            roughness: TextureKind::Constant([0.5; 4].into()),
+            ambient_occlusion: TextureKind::Constant([1.0; 4].into()),
+            caveat: TextureKind::Constant([1.0; 4].into()),
         }
     }
 
@@ -79,15 +83,27 @@ impl MaterialBuilder {
         self
     }
 
-    /// Sets the reflectance to an existing texture map.
-    pub fn with_reflectance(mut self, tex: &Texture) -> Self {
-        self.reflectance = TextureKind::Map(tex.clone());
+    /// Sets the roughness to an existing texture map.
+    pub fn with_metallic(mut self, tex: &Texture) -> Self {
+        self.metallic = TextureKind::Map(tex.clone());
         self
     }
 
     /// Sets the roughness to an existing texture map.
     pub fn with_roughness(mut self, tex: &Texture) -> Self {
         self.roughness = TextureKind::Map(tex.clone());
+        self
+    }
+
+    /// Sets the reflectance to an existing texture map.
+    pub fn with_ambient_occlusion(mut self, tex: &Texture) -> Self {
+        self.ambient_occlusion = TextureKind::Map(tex.clone());
+        self
+    }
+
+    /// Sets the reflectance to an existing texture map.
+    pub fn with_caveat(mut self, tex: &Texture) -> Self {
+        self.caveat = TextureKind::Map(tex.clone());
         self
     }
 
@@ -98,8 +114,9 @@ impl MaterialBuilder {
             emission: self.emission.into_texture(fac)?,
             normal: self.normal.into_texture(fac)?,
             metallic: self.metallic.into_texture(fac)?,
-            reflectance: self.reflectance.into_texture(fac)?,
             roughness: self.roughness.into_texture(fac)?,
+            ambient_occlusion: self.ambient_occlusion.into_texture(fac)?,
+            caveat: self.caveat.into_texture(fac)?,
         })
     }
 }

--- a/amethyst_renderer/src/mtl/mod.rs
+++ b/amethyst_renderer/src/mtl/mod.rs
@@ -58,7 +58,7 @@ impl MaterialBuilder {
             albedo: TextureKind::Constant([0.0, 0.0, 0.5, 1.0].into()),
             emission: TextureKind::Constant([0.0; 4].into()),
             metallic: TextureKind::Constant([0.0; 4].into()),
-            normal: TextureKind::Constant([0.0, 0.0, 1.0, 1.0].into()),
+            normal: TextureKind::Constant([0.5, 0.5, 1.0, 1.0].into()),
             roughness: TextureKind::Constant([0.5; 4].into()),
             ambient_occlusion: TextureKind::Constant([1.0; 4].into()),
             caveat: TextureKind::Constant([1.0; 4].into()),

--- a/amethyst_renderer/src/pass/blit.rs
+++ b/amethyst_renderer/src/pass/blit.rs
@@ -50,8 +50,8 @@ impl BlitBuffer {
     }
 }
 
-impl Into<PassBuilder> for BlitBuffer {
-    fn into(self) -> PassBuilder {
+impl<'a>Into<PassBuilder<'a>> for BlitBuffer {
+    fn into(self) -> PassBuilder<'a> {
         use gfx::texture::{FilterMethod, WrapMode};
 
         let effect = Effect::new_simple_prog(VERT_SRC, FRAG_SRC)

--- a/amethyst_renderer/src/pass/blit.rs
+++ b/amethyst_renderer/src/pass/blit.rs
@@ -50,12 +50,14 @@ impl BlitBuffer {
     }
 }
 
+static SAMPLER_NAMES: [&'static str; 1] = ["blit"];
+
 impl<'a>Into<PassBuilder<'a>> for BlitBuffer {
     fn into(self) -> PassBuilder<'a> {
         use gfx::texture::{FilterMethod, WrapMode};
 
         let effect = Effect::new_simple_prog(VERT_SRC, FRAG_SRC)
-            .with_sampler("blit", FilterMethod::Scale, WrapMode::Clamp);
+            .with_sampler(&SAMPLER_NAMES, FilterMethod::Scale, WrapMode::Clamp);
             // .with_input_target(self.target, "blit")
 
         PassBuilder::post(effect, move |ref mut enc, ref out, ref effect, ref scene| {

--- a/amethyst_renderer/src/pass/blit.rs
+++ b/amethyst_renderer/src/pass/blit.rs
@@ -58,20 +58,20 @@ impl<'a>Into<PassBuilder<'a>> for BlitBuffer {
 
         let effect = Effect::new_simple_prog(VERT_SRC, FRAG_SRC)
             .with_sampler(&SAMPLER_NAMES, FilterMethod::Scale, WrapMode::Clamp);
-            // .with_input_target(self.target, "blit")
+        // .with_input_target(self.target, "blit")
 
-        PassBuilder::post(effect, move |ref mut enc, ref out, ref effect, ref scene| {
-                // let buf = if let Some(i) = buf_idx {
-                //     data.targets[0].color_buf(i).unwrap().target_view
-                // } else {
-                //     data.targets[0].depth_buf().unwrap().target_view
-                // };
+        PassBuilder::simple(effect, move |ref mut enc, ref out, ref effect, ref scene| {
+            // let buf = if let Some(i) = buf_idx {
+            //     data.targets[0].color_buf(i).unwrap().target_view
+            // } else {
+            //     data.targets[0].depth_buf().unwrap().target_view
+            // };
 
-                // enc.draw(&slice, &data.pso.unwrap(), &blit::Data {
-                //     vbuf: vbuf,
-                //     source: (buf, data.samplers[0].clone()),
-                //     out: out.color_buf(0).unwrap().target_view.clone(),
-                // });
-            })
+            // enc.draw(&slice, &data.pso.unwrap(), &blit::Data {
+            //     vbuf: vbuf,
+            //     source: (buf, data.samplers[0].clone()),
+            //     out: out.color_buf(0).unwrap().target_view.clone(),
+            // });
+        })
     }
 }

--- a/amethyst_renderer/src/pass/blit.rs
+++ b/amethyst_renderer/src/pass/blit.rs
@@ -58,7 +58,7 @@ impl<'a>Into<PassBuilder<'a>> for BlitBuffer {
             .with_sampler("blit", FilterMethod::Scale, WrapMode::Clamp);
             // .with_input_target(self.target, "blit")
 
-        PassBuilder::postproc(effect, move |ref mut enc, ref out, ref effect, ref scene| {
+        PassBuilder::post(effect, move |ref mut enc, ref out, ref effect, ref scene| {
                 // let buf = if let Some(i) = buf_idx {
                 //     data.targets[0].color_buf(i).unwrap().target_view
                 // } else {

--- a/amethyst_renderer/src/pass/clear.rs
+++ b/amethyst_renderer/src/pass/clear.rs
@@ -38,7 +38,7 @@ impl ClearTarget {
 
 impl<'a> Into<PassBuilder<'a>> for ClearTarget {
     fn into(self) -> PassBuilder<'a> {
-        PassBuilder::prep(move |ref mut enc, ref out| {
+        PassBuilder::basic(move |ref mut enc, ref out| {
             if let Some(val) = self.color_val {
                 for buf in out.color_bufs() {
                     enc.clear(&buf.as_output, val);

--- a/amethyst_renderer/src/pass/clear.rs
+++ b/amethyst_renderer/src/pass/clear.rs
@@ -38,7 +38,7 @@ impl ClearTarget {
 
 impl<'a> Into<PassBuilder<'a>> for ClearTarget {
     fn into(self) -> PassBuilder<'a> {
-        PassBuilder::function(move |ref mut enc, ref out| {
+        PassBuilder::prep(move |ref mut enc, ref out| {
             if let Some(val) = self.color_val {
                 for buf in out.color_bufs() {
                     enc.clear(&buf.as_output, val);

--- a/amethyst_renderer/src/pass/clear.rs
+++ b/amethyst_renderer/src/pass/clear.rs
@@ -36,8 +36,8 @@ impl ClearTarget {
     }
 }
 
-impl Into<PassBuilder> for ClearTarget {
-    fn into(self) -> PassBuilder {
+impl<'a> Into<PassBuilder<'a>> for ClearTarget {
+    fn into(self) -> PassBuilder<'a> {
         PassBuilder::function(move |ref mut enc, ref out| {
             if let Some(val) = self.color_val {
                 for buf in out.color_bufs() {

--- a/amethyst_renderer/src/pass/flat.rs
+++ b/amethyst_renderer/src/pass/flat.rs
@@ -8,7 +8,7 @@ use pipe::pass::PassBuilder;
 use pipe::{Effect, DepthMode};
 use std::any::{Any, TypeId};
 use std::mem::{self, transmute};
-use vertex::{AttributeNames, Color, Normal, Position, PosNormTex, TextureCoord, VertexFormat};
+use vertex::{AttributeNames, Color, Position, TextureCoord, VertexFormat};
 
 static VERT_SRC: &'static [u8] = include_bytes!("shaders/vertex/basic.glsl");
 static FRAG_SRC: &'static [u8] = include_bytes!("shaders/fragment/flat.glsl");
@@ -25,7 +25,6 @@ impl<V> AttributeNames for DrawFlat<V>
     fn name<A: Any>() -> &'static str {
         match TypeId::of::<A>() {
             t if t == TypeId::of::<Position>() => "position",
-            t if t == TypeId::of::<Normal>() => "normal",
             t if t == TypeId::of::<TextureCoord>() => "tex_coord",
             _ => "", // Unused attribute
         }
@@ -60,7 +59,7 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawFlat<V>
 
         let effect = Effect::new_simple_prog(VERT_SRC, FRAG_SRC)
             .with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1)
-            .with_raw_vertex_buffer(self.named_vertex_attributes.as_ref(), PosNormTex::size() as ElemStride, 0)
+            .with_raw_vertex_buffer(self.named_vertex_attributes.as_ref(), V::size() as ElemStride, 0)
             .with_sampler(&SAMPLER_NAMES, FilterMethod::Scale, WrapMode::Clamp)
             .with_texture("albedo")
             .with_output("color", Some(DepthMode::LessEqualWrite));

--- a/amethyst_renderer/src/pass/flat.rs
+++ b/amethyst_renderer/src/pass/flat.rs
@@ -10,50 +10,8 @@ use std::any::{Any, TypeId};
 use std::mem::{self, transmute};
 use vertex::{AttributeNames, Color, Normal, Position, PosNormTex, TextureCoord, VertexFormat};
 
-static VERT_SRC: &'static [u8] = b"
-    #version 150 core
-
-    layout (std140) uniform VertexArgs {
-        uniform mat4 proj;
-        uniform mat4 view;
-        uniform mat4 model;
-    };
-
-    in vec3 position;
-    in vec3 normal;
-    in vec2 tex_coord;
-
-    out VertexData {
-        vec4 position;
-        vec3 normal;
-        vec2 tex_coord;
-    } vertex_data;
-
-    void main() {
-        vertex_data.position = model * vec4(position, 1.0);
-        vertex_data.normal = mat3(model) * normal;
-        vertex_data.tex_coord = tex_coord;
-        gl_Position = proj * view * vertex_data.position;
-    }
-";
-
-static FRAG_SRC: &'static [u8] = b"
-    #version 150 core
-
-    uniform sampler2D albedo;
-
-    in VertexData {
-        vec4 position;
-        vec3 normal;
-        vec2 tex_coord;
-    } vertex_data;
-
-    out vec4 color;
-
-    void main() {
-        color = texture(albedo, vec2(0, 0));
-    }
-";
+static VERT_SRC: &'static [u8] = include_bytes!("shaders/vertex/basic.glsl");
+static FRAG_SRC: &'static [u8] = include_bytes!("shaders/fragment/flat.glsl");
 
 /// Draw mesh without lighting
 #[derive(Clone, Debug, PartialEq)]
@@ -85,6 +43,8 @@ impl<V> DrawFlat<V>
     }
 }
 
+static SAMPLER_NAMES: [&'static str; 1] = ["albedo"];
+
 impl<'a, V> Into<PassBuilder<'a>> for &'a DrawFlat<V>
     where V: VertexFormat
 {
@@ -101,9 +61,9 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawFlat<V>
         let effect = Effect::new_simple_prog(VERT_SRC, FRAG_SRC)
             .with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1)
             .with_raw_vertex_buffer(self.named_vertex_attributes.as_ref(), PosNormTex::size() as ElemStride, 0)
-            .with_sampler("albedo", FilterMethod::Scale, WrapMode::Clamp)
+            .with_sampler(&SAMPLER_NAMES, FilterMethod::Scale, WrapMode::Clamp)
             .with_texture("albedo")
-            .with_output("color", None);
+            .with_output("color", Some(DepthMode::LessEqualWrite));
 
         PassBuilder::main(effect, move |ref mut enc, ref out, ref effect, ref scene, ref model| {
             let vertex_args = scene.active_camera().map(|cam| VertexArgs {
@@ -127,6 +87,7 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawFlat<V>
             data.samplers.push(effect.samplers["albedo"].clone());
             data.textures.push(model.material.albedo.view().clone());
             data.out_colors.extend(out.color_buf(0).map(|cb| cb.as_output.clone()));
+            data.out_depth = out.depth_buf().map(|db| (db.as_output.clone(), (0, 0)));
             enc.draw(slice, &effect.pso, &data);
         })
     }

--- a/amethyst_renderer/src/pass/flat.rs
+++ b/amethyst_renderer/src/pass/flat.rs
@@ -1,0 +1,133 @@
+//! Blits a color or depth buffer from one Target onto another.
+
+use cam::Camera;
+use cgmath::{Matrix4, One};
+use gfx;
+use gfx::pso::buffer::{ElemStride, NonInstanced};
+use pipe::pass::PassBuilder;
+use pipe::{Effect, DepthMode};
+use std::any::{Any, TypeId};
+use std::mem::{self, transmute};
+use vertex::{AttributeNames, Color, Normal, Position, PosNormTex, TextureCoord, VertexFormat};
+
+static VERT_SRC: &'static [u8] = b"
+    #version 150 core
+
+    layout (std140) uniform VertexArgs {
+        uniform mat4 proj;
+        uniform mat4 view;
+        uniform mat4 model;
+    };
+
+    in vec3 position;
+    in vec3 normal;
+    in vec2 tex_coord;
+
+    out VertexData {
+        vec4 position;
+        vec3 normal;
+        vec2 tex_coord;
+    } vertex_data;
+
+    void main() {
+        vertex_data.position = model * vec4(position, 1.0);
+        vertex_data.normal = mat3(model) * normal;
+        vertex_data.tex_coord = tex_coord;
+        gl_Position = proj * view * vertex_data.position;
+    }
+";
+
+static FRAG_SRC: &'static [u8] = b"
+    #version 150 core
+
+    uniform sampler2D albedo;
+
+    in VertexData {
+        vec4 position;
+        vec3 normal;
+        vec2 tex_coord;
+    } vertex_data;
+
+    out vec4 color;
+
+    void main() {
+        color = texture(albedo, vec2(0, 0));
+    }
+";
+
+/// Draw mesh without lighting
+#[derive(Clone, Debug, PartialEq)]
+pub struct DrawFlat<V: VertexFormat> {
+    named_vertex_attributes: V::NamedAttributes,
+}
+
+impl<V> AttributeNames for DrawFlat<V>
+    where V: VertexFormat
+{
+    fn name<A: Any>() -> &'static str {
+        match TypeId::of::<A>() {
+            t if t == TypeId::of::<Position>() => "position",
+            t if t == TypeId::of::<Normal>() => "normal",
+            t if t == TypeId::of::<TextureCoord>() => "tex_coord",
+            _ => "", // Unused attribute
+        }
+    }
+}
+
+impl<V> DrawFlat<V>
+    where V: VertexFormat
+{
+    /// Create instance of `DrawFlat` pass
+    pub fn new() -> Self {
+        DrawFlat {
+            named_vertex_attributes: V::named_attributes::<Self>(),
+        }
+    }
+}
+
+impl<'a, V> Into<PassBuilder<'a>> for &'a DrawFlat<V>
+    where V: VertexFormat
+{
+    fn into(self) -> PassBuilder<'a> {
+        use gfx::texture::{FilterMethod, WrapMode};
+
+        #[derive(Clone, Copy, Debug)]
+        struct VertexArgs {
+            proj: [[f32;4]; 4],
+            view: [[f32;4]; 4],
+            model: [[f32;4]; 4],
+        };
+
+        let effect = Effect::new_simple_prog(VERT_SRC, FRAG_SRC)
+            .with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1)
+            .with_raw_vertex_buffer(self.named_vertex_attributes.as_ref(), PosNormTex::size() as ElemStride, 0)
+            .with_sampler("albedo", FilterMethod::Scale, WrapMode::Clamp)
+            .with_texture("albedo")
+            .with_output("color", None);
+
+        PassBuilder::main(effect, move |ref mut enc, ref out, ref model, ref effect, ref scene| {
+            let vertex_args = scene.active_camera().map(|cam| VertexArgs {
+                proj: cam.proj.into(),
+                view: Matrix4::look_at(cam.eye, cam.eye + cam.forward, cam.up).into(),
+                model: model.pos.into(),
+            }).unwrap_or_else(|| VertexArgs {
+                proj: Matrix4::one().into(),
+                view: Matrix4::one().into(),
+                model: model.pos.into(),
+            });
+            let vertex_args_buf = effect.const_bufs["VertexArgs"].clone();
+            
+            // FIXME: update raw buffer without transmute
+            enc.update_constant_buffer::<VertexArgs>(unsafe { transmute(&vertex_args_buf) }, &vertex_args);
+
+            let mut data = effect.pso_data.clone();
+            data.const_bufs.push(vertex_args_buf);
+            let (vertex, slice) = model.mesh.geometry();
+            data.vertex_bufs.push(vertex.clone());
+            data.samplers.push(effect.samplers["albedo"].clone());
+            data.textures.push(model.material.albedo.view().clone());
+            data.out_colors.extend(out.color_buf(0).map(|cb| cb.as_output.clone()));
+            enc.draw(slice, &effect.pso, &data);
+        })
+    }
+}

--- a/amethyst_renderer/src/pass/flat.rs
+++ b/amethyst_renderer/src/pass/flat.rs
@@ -105,7 +105,7 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawFlat<V>
             .with_texture("albedo")
             .with_output("color", None);
 
-        PassBuilder::main(effect, move |ref mut enc, ref out, ref model, ref effect, ref scene| {
+        PassBuilder::main(effect, move |ref mut enc, ref out, ref effect, ref scene, ref model| {
             let vertex_args = scene.active_camera().map(|cam| VertexArgs {
                 proj: cam.proj.into(),
                 view: Matrix4::look_at(cam.eye, cam.eye + cam.forward, cam.up).into(),

--- a/amethyst_renderer/src/pass/mod.rs
+++ b/amethyst_renderer/src/pass/mod.rs
@@ -2,6 +2,8 @@
 
 pub use self::blit::BlitBuffer;
 pub use self::clear::ClearTarget;
+pub use self::flat::DrawFlat;
 
 mod blit;
 mod clear;
+mod flat;

--- a/amethyst_renderer/src/pass/mod.rs
+++ b/amethyst_renderer/src/pass/mod.rs
@@ -3,7 +3,9 @@
 pub use self::blit::BlitBuffer;
 pub use self::clear::ClearTarget;
 pub use self::flat::DrawFlat;
+pub use self::shaded::DrawShaded;
 
 mod blit;
 mod clear;
 mod flat;
+mod shaded;

--- a/amethyst_renderer/src/pass/shaded.rs
+++ b/amethyst_renderer/src/pass/shaded.rs
@@ -7,7 +7,7 @@ use gfx::pso::buffer::{ElemStride, NonInstanced};
 use gfx::shade::core::UniformValue;
 use gfx::traits::Pod;
 use pipe::pass::PassBuilder;
-use pipe::{Effect, DepthMode};
+use pipe::{DepthMode, Effect};
 use std::any::{Any, TypeId};
 use std::marker::PhantomData;
 use std::mem::{self, transmute};
@@ -27,9 +27,13 @@ pub struct DrawShaded<V> {
 }
 
 impl<V> DrawShaded<V>
-    where V: VertexFormat + WithField<Position> + WithField<Normal> + WithField<Tangent> + WithField<TextureCoord>
+    where V: VertexFormat +
+          WithField<Position> +
+          WithField<Normal> +
+          WithField<Tangent> +
+          WithField<TextureCoord>
 {
-    /// Create instance of `DrawShaded` pass
+/// Create instance of `DrawShaded` pass
     pub fn new() -> Self {
         DrawShaded {
             vertex_attributes: [
@@ -43,15 +47,13 @@ impl<V> DrawShaded<V>
     }
 }
 
-static SAMPLER_NAMES: [&'static str; 7] = [
-    "sampler_roughness",
-    "sampler_caveat",
-    "sampler_metallic",
-    "sampler_ambient_occlusion",
-    "sampler_emission",
-    "sampler_normal",
-    "sampler_albedo",
-];
+static SAMPLER_NAMES: [&'static str; 7] = ["sampler_roughness",
+                                           "sampler_caveat",
+                                           "sampler_metallic",
+                                           "sampler_ambient_occlusion",
+                                           "sampler_emission",
+                                           "sampler_normal",
+                                           "sampler_albedo"];
 
 
 fn pad(x: [f32; 3]) -> [f32; 4] {
@@ -66,13 +68,13 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawShaded<V>
 
         #[derive(Clone, Copy, Debug)]
         struct VertexArgs {
-            proj: [[f32;4]; 4],
-            view: [[f32;4]; 4],
-            model: [[f32;4]; 4],
+            proj: [[f32; 4]; 4],
+            view: [[f32; 4]; 4],
+            model: [[f32; 4]; 4],
         };
         #[derive(Clone, Copy, Debug)]
         struct FragmentArgs {
-            point_light_count: i32, 
+            point_light_count: i32,
             directional_light_count: i32,
         };
         #[derive(Clone, Copy, Debug)]
@@ -109,22 +111,32 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawShaded<V>
             .with_texture("sampler_albedo")
             .with_output("out_color", Some(DepthMode::LessEqualWrite));
 
-        PassBuilder::main(effect, move |ref mut enc, ref out, ref effect, ref scene, ref model| {
-            
+        PassBuilder::model(effect,
+                           move |ref mut enc, ref out, ref effect, ref scene, ref model| {
+
             let mut data = effect.pso_data.clone();
             {
-                let vertex_args = scene.active_camera().map(|cam| VertexArgs {
-                    proj: cam.proj.into(),
-                    view: Matrix4::look_at(cam.eye, cam.eye + cam.forward, cam.up).into(),
-                    model: model.pos.into(),
-                }).unwrap_or_else(|| VertexArgs {
-                    proj: Matrix4::one().into(),
-                    view: Matrix4::one().into(),
-                    model: model.pos.into(),
-                });
+                let vertex_args = scene
+                    .active_camera()
+                    .map(|cam| {
+                             VertexArgs {
+                                 proj: cam.proj.into(),
+                                 view: Matrix4::look_at(cam.eye, cam.eye + cam.forward, cam.up)
+                                     .into(),
+                                 model: model.pos.into(),
+                             }
+                         })
+                    .unwrap_or_else(|| {
+                                        VertexArgs {
+                                            proj: Matrix4::one().into(),
+                                            view: Matrix4::one().into(),
+                                            model: model.pos.into(),
+                                        }
+                                    });
                 let vertex_args_buf = effect.const_bufs["VertexArgs"].clone();
                 // FIXME: update raw buffer without transmute
-                enc.update_constant_buffer::<VertexArgs>(unsafe { transmute(&vertex_args_buf) }, &vertex_args);
+                enc.update_constant_buffer::<VertexArgs>(unsafe { transmute(&vertex_args_buf) },
+                                                         &vertex_args);
                 data.const_bufs.push(vertex_args_buf);
             }
             {
@@ -132,16 +144,20 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawShaded<V>
                 let mut directional_lights = Vec::new();
                 for (i, light) in scene.lights().iter().enumerate() {
                     match *light {
-                        Light::Directional(ref light) => directional_lights.push(DirectionalLight {
-                            direction: light.direction.into(),
-                            color: light.color.into(),
-                        }),
-                        Light::Point(ref light) => point_lights.push(PointLight {
-                            position: pad(light.center.into()),
-                            color: pad(light.color.into()),
-                            intensity: light.intensity,
-                            _pad: [0.0; 3],
-                        }),
+                        Light::Directional(ref light) => {
+                            directional_lights.push(DirectionalLight {
+                                                        direction: light.direction.into(),
+                                                        color: light.color.into(),
+                                                    })
+                        }
+                        Light::Point(ref light) => {
+                            point_lights.push(PointLight {
+                                                  position: pad(light.center.into()),
+                                                  color: pad(light.color.into()),
+                                                  intensity: light.intensity,
+                                                  _pad: [0.0; 3],
+                                              })
+                        }
                         _ => {}
                     }
                 }
@@ -152,48 +168,74 @@ impl<'a, V> Into<PassBuilder<'a>> for &'a DrawShaded<V>
                 };
 
                 let fragment_args_buf = effect.const_bufs["FragmentArgs"].clone();
-                enc.update_constant_buffer::<FragmentArgs>(unsafe { transmute(&fragment_args_buf) }, &fragment_args);
+                enc.update_constant_buffer::<FragmentArgs>(unsafe {
+                                                               transmute(&fragment_args_buf)
+                                                           },
+                                                           &fragment_args);
 
                 let point_lights_buf = effect.const_bufs["PointLights"].clone();
-                enc.update_buffer::<PointLight>(unsafe { transmute(&point_lights_buf) }, &point_lights[..], 0);
+                enc.update_buffer::<PointLight>(unsafe { transmute(&point_lights_buf) },
+                                                &point_lights[..],
+                                                0);
 
                 let directional_lights_buf = effect.const_bufs["DirectionalLight"].clone();
-                enc.update_buffer::<DirectionalLight>(unsafe { transmute(&directional_lights_buf) }, &directional_lights[..], 0);
+                enc.update_buffer::<DirectionalLight>(unsafe {
+                                                          transmute(&directional_lights_buf)
+                                                      },
+                                                      &directional_lights[..],
+                                                      0);
 
                 data.const_bufs.push(fragment_args_buf);
                 data.const_bufs.push(point_lights_buf);
                 data.const_bufs.push(directional_lights_buf);
             }
             {
-                data.globals.push(UniformValue::F32Vector3([0.005; 3].into()));
-                data.globals.push(UniformValue::F32Vector3(scene.active_camera().map(|cam| cam.eye.into()).unwrap_or([0.0; 3])));
+                data.globals
+                    .push(UniformValue::F32Vector3([0.005; 3].into()));
+                data.globals
+                    .push(UniformValue::F32Vector3(scene
+                                                       .active_camera()
+                                                       .map(|cam| cam.eye.into())
+                                                       .unwrap_or([0.0; 3])));
             }
             {
-                data.samplers.push(effect.samplers["sampler_roughness"].clone());
-                data.textures.push(model.material.roughness.view().clone());
-                
-                data.samplers.push(effect.samplers["sampler_caveat"].clone());
+                data.samplers
+                    .push(effect.samplers["sampler_roughness"].clone());
+                data.textures
+                    .push(model.material.roughness.view().clone());
+
+                data.samplers
+                    .push(effect.samplers["sampler_caveat"].clone());
                 data.textures.push(model.material.caveat.view().clone());
-                
-                data.samplers.push(effect.samplers["sampler_metallic"].clone());
-                data.textures.push(model.material.metallic.view().clone());
-                
-                data.samplers.push(effect.samplers["sampler_ambient_occlusion"].clone());
-                data.textures.push(model.material.ambient_occlusion.view().clone());
-                
-                data.samplers.push(effect.samplers["sampler_emission"].clone());
-                data.textures.push(model.material.emission.view().clone());
-                
-                data.samplers.push(effect.samplers["sampler_normal"].clone());
+
+                data.samplers
+                    .push(effect.samplers["sampler_metallic"].clone());
+                data.textures
+                    .push(model.material.metallic.view().clone());
+
+                data.samplers
+                    .push(effect.samplers["sampler_ambient_occlusion"].clone());
+                data.textures
+                    .push(model.material.ambient_occlusion.view().clone());
+
+                data.samplers
+                    .push(effect.samplers["sampler_emission"].clone());
+                data.textures
+                    .push(model.material.emission.view().clone());
+
+                data.samplers
+                    .push(effect.samplers["sampler_normal"].clone());
                 data.textures.push(model.material.normal.view().clone());
 
-                data.samplers.push(effect.samplers["sampler_albedo"].clone());
+                data.samplers
+                    .push(effect.samplers["sampler_albedo"].clone());
                 data.textures.push(model.material.albedo.view().clone());
             }
 
             let (vertex, slice) = model.mesh.geometry();
             data.vertex_bufs.push(vertex.clone());
-            data.out_colors.extend(out.color_buf(0).map(|cb| cb.as_output.clone()));
+            data.out_colors
+                .extend(out.color_buf(0).map(|cb| cb.as_output.clone()));
             data.out_depth = out.depth_buf().map(|db| (db.as_output.clone(), (0, 0)));
             enc.draw(slice, &effect.pso, &data);
         })

--- a/amethyst_renderer/src/pass/shaded.rs
+++ b/amethyst_renderer/src/pass/shaded.rs
@@ -1,0 +1,213 @@
+//! Blits a color or depth buffer from one Target onto another.
+
+use cam::Camera;
+use cgmath::{Matrix4, One};
+use gfx;
+use gfx::pso::buffer::{ElemStride, NonInstanced};
+use gfx::shade::core::UniformValue;
+use gfx::traits::Pod;
+use pipe::pass::PassBuilder;
+use pipe::{Effect, DepthMode};
+use std::any::{Any, TypeId};
+use std::mem::{self, transmute};
+use vertex::{AttributeNames, Color, Normal, Position, PosNormTex, TextureCoord, VertexFormat};
+use light::{DirectionalLight, Light, PointLight};
+use scene::Scene;
+use std::io::Read;
+
+static VERT_SRC: &'static [u8] = include_bytes!("shaders/vertex/basic.glsl");
+
+
+//pub static FRAG_SRC: &'static [u8] = include_bytes!("shaders/fragment/pbm.glsl");
+
+/// Draw mesh without lighting
+#[derive(Clone, Debug, PartialEq)]
+pub struct DrawShaded<V: VertexFormat> {
+    named_vertex_attributes: V::NamedAttributes,
+    fragment_shader: Vec<u8>,
+}
+
+impl<V> AttributeNames for DrawShaded<V>
+    where V: VertexFormat
+{
+    fn name<A: Any>() -> &'static str {
+        match TypeId::of::<A>() {
+            t if t == TypeId::of::<Position>() => "position",
+            t if t == TypeId::of::<Normal>() => "normal",
+            t if t == TypeId::of::<TextureCoord>() => "tex_coord",
+            _ => "", // Unused attribute
+        }
+    }
+}
+
+impl<V> DrawShaded<V>
+    where V: VertexFormat
+{
+    /// Create instance of `DrawShaded` pass
+    pub fn new() -> Self {
+        DrawShaded {
+            named_vertex_attributes: V::named_attributes::<Self>(),
+            fragment_shader: {
+                let mut data = Vec::new();
+                ::std::fs::File::open("src/pass/shaders/fragment/pbm.glsl").unwrap().read_to_end(&mut data).unwrap();
+                data
+            }
+        }
+    }
+}
+
+static SAMPLER_NAMES: [&'static str; 7] = [
+    "sampler_albedo",
+    "sampler_emission",
+    "sampler_normal",
+    "sampler_metallic",
+    "sampler_roughness",
+    "sampler_ambient_occlusion",
+    "sampler_caveat",
+];
+
+
+fn pad(x: [f32; 3]) -> [f32; 4] {
+    [x[0], x[1], x[2], 1.0]
+}
+
+impl<'a, V> Into<PassBuilder<'a>> for &'a DrawShaded<V>
+    where V: VertexFormat
+{
+    fn into(self) -> PassBuilder<'a> {
+        use gfx::texture::{FilterMethod, WrapMode};
+
+        #[derive(Clone, Copy, Debug)]
+        struct VertexArgs {
+            proj: [[f32;4]; 4],
+            view: [[f32;4]; 4],
+            model: [[f32;4]; 4],
+        };
+        #[derive(Clone, Copy, Debug)]
+        struct FragmentArgs {
+            point_light_count: i32, 
+            directional_light_count: i32,
+        };
+        #[derive(Clone, Copy, Debug)]
+        #[repr(C)]
+        struct PointLight {
+            position: [f32; 4],
+            color: [f32; 4],
+            intensity: f32,
+            _pad: [f32; 3],
+        };
+        unsafe impl Pod for PointLight {}
+        #[derive(Clone, Copy, Debug)]
+        struct DirectionalLight {
+            direction: [f32; 3],
+            color: [f32; 3],
+        };
+        unsafe impl Pod for DirectionalLight {}
+
+        let effect = Effect::new_simple_prog(VERT_SRC, &self.fragment_shader)
+            .with_raw_vertex_buffer(self.named_vertex_attributes.as_ref(), PosNormTex::size() as ElemStride, 0)
+            .with_raw_constant_buffer("VertexArgs", mem::size_of::<VertexArgs>(), 1)
+            .with_raw_constant_buffer("FragmentArgs", mem::size_of::<FragmentArgs>(), 1)
+            .with_raw_constant_buffer("PointLights", mem::size_of::<PointLight>(), 512)
+            .with_raw_constant_buffer("DirectionalLight", mem::size_of::<DirectionalLight>(), 16)
+            .with_raw_global("ambient_color")
+            .with_raw_global("camera_position")
+            .with_sampler(&SAMPLER_NAMES, FilterMethod::Scale, WrapMode::Clamp)
+            .with_texture("sampler_roughness")
+            .with_texture("sampler_caveat")
+            .with_texture("sampler_metallic")
+            .with_texture("sampler_emission")
+            .with_texture("sampler_ambient_occlusion")
+            .with_texture("sampler_albedo")
+            .with_texture("sampler_normal")
+            .with_output("out_color", None);
+
+        PassBuilder::main(effect, move |ref mut enc, ref out, ref effect, ref scene, ref model| {
+            
+            let mut data = effect.pso_data.clone();
+            {
+                let vertex_args = scene.active_camera().map(|cam| VertexArgs {
+                    proj: cam.proj.into(),
+                    view: Matrix4::look_at(cam.eye, cam.eye + cam.forward, cam.up).into(),
+                    model: model.pos.into(),
+                }).unwrap_or_else(|| VertexArgs {
+                    proj: Matrix4::one().into(),
+                    view: Matrix4::one().into(),
+                    model: model.pos.into(),
+                });
+                let vertex_args_buf = effect.const_bufs["VertexArgs"].clone();
+                // FIXME: update raw buffer without transmute
+                enc.update_constant_buffer::<VertexArgs>(unsafe { transmute(&vertex_args_buf) }, &vertex_args);
+                data.const_bufs.push(vertex_args_buf);
+            }
+            {
+                let mut point_lights = Vec::new();
+                let mut directional_lights = Vec::new();
+                for (i, light) in scene.lights().iter().enumerate() {
+                    match *light {
+                        Light::Directional(ref light) => directional_lights.push(DirectionalLight {
+                            direction: light.direction.into(),
+                            color: light.color.into(),
+                        }),
+                        Light::Point(ref light) => point_lights.push(PointLight {
+                            position: pad(light.center.into()),
+                            color: pad(light.color.into()),
+                            intensity: light.intensity,
+                            _pad: [0.0; 3],
+                        }),
+                        _ => {}
+                    }
+                }
+
+                let fragment_args = FragmentArgs {
+                    point_light_count: point_lights.len() as i32,
+                    directional_light_count: directional_lights.len() as i32,
+                };
+
+                let fragment_args_buf = effect.const_bufs["FragmentArgs"].clone();
+                enc.update_constant_buffer::<FragmentArgs>(unsafe { transmute(&fragment_args_buf) }, &fragment_args);
+
+                let point_lights_buf = effect.const_bufs["PointLights"].clone();
+                enc.update_buffer::<PointLight>(unsafe { transmute(&point_lights_buf) }, &point_lights[..], 0);
+
+                let directional_lights_buf = effect.const_bufs["DirectionalLight"].clone();
+                enc.update_buffer::<DirectionalLight>(unsafe { transmute(&directional_lights_buf) }, &directional_lights[..], 0);
+
+                data.const_bufs.push(fragment_args_buf);
+                data.const_bufs.push(point_lights_buf);
+                data.const_bufs.push(directional_lights_buf);
+            }
+            {
+                data.globals.push(UniformValue::F32Vector3([0.005; 3].into()));
+                data.globals.push(UniformValue::F32Vector3(scene.active_camera().map(|cam| cam.eye.into()).unwrap_or([0.0; 3])));
+            }
+            {
+                data.samplers.push(effect.samplers["sampler_roughness"].clone());
+                data.textures.push(model.material.roughness.view().clone());
+                
+                data.samplers.push(effect.samplers["sampler_caveat"].clone());
+                data.textures.push(model.material.caveat.view().clone());
+                
+                data.samplers.push(effect.samplers["sampler_metallic"].clone());
+                data.textures.push(model.material.metallic.view().clone());
+                
+                data.samplers.push(effect.samplers["sampler_emission"].clone());
+                data.textures.push(model.material.emission.view().clone());
+                
+                data.samplers.push(effect.samplers["sampler_ambient_occlusion"].clone());
+                data.textures.push(model.material.ambient_occlusion.view().clone());
+
+                data.samplers.push(effect.samplers["sampler_albedo"].clone());
+                data.textures.push(model.material.albedo.view().clone());
+                
+                data.samplers.push(effect.samplers["sampler_normal"].clone());
+                data.textures.push(model.material.normal.view().clone());
+            }
+
+            let (vertex, slice) = model.mesh.geometry();
+            data.vertex_bufs.push(vertex.clone());
+            data.out_colors.extend(out.color_buf(0).map(|cb| cb.as_output.clone()));
+            enc.draw(slice, &effect.pso, &data);
+        })
+    }
+}

--- a/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
@@ -1,4 +1,3 @@
-
 #version 150 core
 
 uniform sampler2D albedo;

--- a/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
@@ -1,0 +1,16 @@
+
+#version 150 core
+
+uniform sampler2D albedo;
+
+in VertexData {
+    vec4 position;
+    vec3 normal;
+    vec2 tex_coord;
+} vertex;
+
+out vec4 color;
+
+void main() {
+    color = texture(albedo, vertex.tex_coord);
+}

--- a/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/flat.glsl
@@ -6,6 +6,7 @@ uniform sampler2D albedo;
 in VertexData {
     vec4 position;
     vec3 normal;
+    vec3 tangent;
     vec2 tex_coord;
 } vertex;
 

--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -1,0 +1,115 @@
+
+#version 150 core
+
+layout (std140) uniform FragmentArgs {
+    int point_light_count;
+    int directional_light_count;
+};
+
+struct PointLight {
+    vec4 position;
+    vec4 color;
+    float intensity;
+    float radius;
+    float smoothness;
+    float _pad;
+};
+
+layout (std140) uniform PointLights {
+    PointLight plight[512];
+};
+
+struct DirectionalLight {
+    vec3 direction;
+    vec3 color;
+};
+
+layout (std140) uniform DirectionalLights {
+    DirectionalLight dlight[16];
+};
+
+uniform vec3 ambient_color;
+uniform vec3 camera_position;
+
+uniform sampler2D sampler_albedo;
+uniform sampler2D sampler_emission;
+uniform sampler2D sampler_normal;
+uniform sampler2D sampler_metallic;
+uniform sampler2D sampler_roughness;
+uniform sampler2D sampler_ambient_occlusion;
+uniform sampler2D sampler_caveat;
+
+in VertexData {
+    vec4 position;
+    vec3 normal;
+    vec2 tex_coord;
+} vertex;
+
+out vec4 out_color;
+
+const float PI = 3.14159265359;
+
+float normal_distribution(vec3 N, vec3 H, float a) {
+    float a2 = a * a;
+    float NdotH = max(dot(N, H), 0.0);
+    float NdotH2 = NdotH*NdotH;
+
+    float denom = (NdotH2 * (a2 - 1.0) + 1.0);
+    denom = PI * denom * denom;
+
+    return a2 / denom;
+}
+
+void main() {
+    vec3 albedo             = texture(sampler_albedo, vertex.tex_coord).rgb;
+    vec3 emission           = texture(sampler_emission, vertex.tex_coord).rgb; // TODO: Use emission
+    float metallic          = texture(sampler_metallic, vertex.tex_coord).r;
+    float roughness         = texture(sampler_roughness, vertex.tex_coord).r;
+    float ambient_occlusion = texture(sampler_ambient_occlusion, vertex.tex_coord).r;
+    float caveat            = texture(sampler_caveat, vertex.tex_coord).r;
+
+    float roughness2 = roughness * roughness;
+
+    vec3 fresnel_base = mix(vec3(0.04), albedo, metallic);
+
+    // vec3 normal = magic(vertex.normal, texture(sampler_normal, tex_coord))
+    // TODO: Calculate normals from vertex normal and normal/tangent map
+    vec3 normal = normalize(vertex.normal);
+
+    vec3 lighted = vec3(0.0);
+    for (int i = 0; i < point_light_count; i++) {
+        vec3 view_direction = normalize(camera_position - vertex.position.xyz);
+        vec3 light_direction = normalize(plight[i].position.xyz - vertex.position.xyz);
+        vec3 halfway = normalize(view_direction + light_direction);
+        float intensity = plight[i].intensity / dot(light_direction, light_direction);
+
+        float normal_distribution = normal_distribution(normal, halfway, roughness2);
+
+        float a1 = roughness2 + 1.0;
+        float k = a1 * a1 / 8.0;
+        float NdotV = max(dot(normal, view_direction), 0.0);
+        float NdotL = max(dot(normal, light_direction), 0.0);
+        float denom = NdotV * (1.0 - k) + k;
+        float ggx1 = NdotV / denom;
+
+        denom = NdotL * (1.0 - k) + k;
+        float ggx2 = NdotL / denom;
+        float geometry = ggx1 * ggx2;
+
+        vec3 fresnel = fresnel_base + (1.0 - fresnel_base) * pow(1.0 - NdotV, 5.0);
+
+        vec3 diffuse = vec3(1.0) - fresnel;
+        diffuse *= 1.0 - metallic;
+
+        vec3 nominator = normal_distribution * geometry * fresnel;
+        float denominator = 4 * NdotV * NdotL + 0.0001;
+        vec3 specular = nominator / denominator;
+
+        lighted += (diffuse * albedo / PI + specular) * plight[i].color.rgb * intensity * NdotL;
+    }
+
+    vec3 ambient = ambient_color * albedo * ambient_occlusion;
+    vec3 color = ambient + lighted;
+   
+    out_color = vec4(color, 1.0);
+}

--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -1,4 +1,3 @@
-
 #version 150 core
 
 layout (std140) uniform FragmentArgs {

--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -90,6 +90,8 @@ void main() {
         float k = a1 * a1 / 8.0;
         float NdotV = max(dot(normal, view_direction), 0.0);
         float NdotL = max(dot(normal, light_direction), 0.0);
+        float HdotV = max(dot(halfway, view_direction), 0.0);
+
         float denom = NdotV * (1.0 - k) + k;
         float ggx1 = NdotV / denom;
 
@@ -97,7 +99,7 @@ void main() {
         float ggx2 = NdotL / denom;
         float geometry = ggx1 * ggx2;
 
-        vec3 fresnel = fresnel_base + (1.0 - fresnel_base) * pow(1.0 - NdotV, 5.0);
+        vec3 fresnel = fresnel_base + (1.0 - fresnel_base) * pow(1.0 - HdotV, 5.0);
 
         vec3 diffuse = vec3(1.0) - fresnel;
         diffuse *= 1.0 - metallic;

--- a/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
+++ b/amethyst_renderer/src/pass/shaders/fragment/pbm.glsl
@@ -42,6 +42,7 @@ uniform sampler2D sampler_caveat;
 in VertexData {
     vec4 position;
     vec3 normal;
+    vec3 tangent;
     vec2 tex_coord;
 } vertex;
 

--- a/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
@@ -8,17 +8,20 @@ layout (std140) uniform VertexArgs {
 
 in vec3 position;
 in vec3 normal;
+in vec3 tangent;
 in vec2 tex_coord;
 
 out VertexData {
     vec4 position;
     vec3 normal;
+    vec3 tangent;
     vec2 tex_coord;
 } vertex;
 
 void main() {
     vertex.position = model * vec4(position, 1.0);
     vertex.normal = mat3(model) * normal;
+    vertex.tangent = mat3(model) * tangent;
     vertex.tex_coord = tex_coord;
     gl_Position = proj * view * vertex.position;
 }

--- a/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
@@ -1,0 +1,24 @@
+
+#version 150 core
+layout (std140) uniform VertexArgs {
+    uniform mat4 proj;
+    uniform mat4 view;
+    uniform mat4 model;
+};
+
+in vec3 position;
+in vec3 normal;
+in vec2 tex_coord;
+
+out VertexData {
+    vec4 position;
+    vec3 normal;
+    vec2 tex_coord;
+} vertex;
+
+void main() {
+    vertex.position = model * vec4(position, 1.0);
+    vertex.normal = mat3(model) * normal;
+    vertex.tex_coord = tex_coord;
+    gl_Position = proj * view * vertex.position;
+}

--- a/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
+++ b/amethyst_renderer/src/pass/shaders/vertex/basic.glsl
@@ -1,5 +1,5 @@
-
 #version 150 core
+
 layout (std140) uniform VertexArgs {
     uniform mat4 proj;
     uniform mat4 view;

--- a/amethyst_renderer/src/pipe/effect/mod.rs
+++ b/amethyst_renderer/src/pipe/effect/mod.rs
@@ -160,14 +160,14 @@ impl<'a> EffectBuilder<'a> {
 
     /// Adds a global constant to this `Effect`.
     pub fn with_raw_global(mut self, name: &'a str) -> Self {
-        self.init.globals.push(name.into());
+        self.init.globals.push(name);
         self
     }
 
     /// Adds a raw uniform constant to this `Effect`.
     /// Requests a new constant buffer to be created
     pub fn with_raw_constant_buffer(mut self, name: &'a str, size: usize, num: usize) -> Self {
-        self.const_bufs.insert(name.into(), BufferInfo {
+        self.const_bufs.insert(name, BufferInfo {
             role: BufferRole::Constant,
             bind: Bind::empty(),
             usage: Usage::Dynamic,
@@ -193,17 +193,15 @@ impl<'a> EffectBuilder<'a> {
     }
 
     /// Requests a new texture sampler be created for this `Effect`.
-    pub fn with_sampler(mut self, names: &'a [&'a str], f: FilterMethod, w: WrapMode) -> Self
-    {
+    pub fn with_sampler(mut self, names: &'a [&'a str], f: FilterMethod, w: WrapMode) -> Self {
         self.samplers.insert(SamplerInfo::new(f, w), names);
         self.init.samplers.extend(names);
         self
     }
 
     /// Adds a texture to this `Effect`
-    pub fn with_texture(mut self, name: &'a str) -> Self
-    {
-        self.init.textures.push(name.into());
+    pub fn with_texture(mut self, name: &'a str) -> Self {
+        self.init.textures.push(name);
         self
     }
 

--- a/amethyst_renderer/src/pipe/effect/pso.rs
+++ b/amethyst_renderer/src/pipe/effect/pso.rs
@@ -41,33 +41,42 @@ impl<'d> PipelineInit for Init<'d> {
     fn link_to<'r>(&self, desc: &mut Descriptor, info: &'r ProgramInfo) -> InitResult<'r, Meta> {
         let mut meta = Meta::default();
 
-        for (info, cbuf) in info.constant_buffers.iter().zip(&self.const_bufs) {
+        for cbuf in self.const_bufs.iter() {
             // println!("Link constant {:?}/{:?}", info.name, cbuf);
             let mut meta_cbuf = <RawConstantBuffer as DataLink<'d>>::new();
-            if let Some(res) = meta_cbuf.link_constant_buffer(info, cbuf) {
-                // println!("Linked {:?}", res);
-                let d = res.map_err(|e| InitError::ConstantBuffer(info.name.as_str(), Some(e)))?;
-                meta.const_bufs.push(meta_cbuf);
-                desc.constant_buffers[info.slot as usize] = Some(d);
+            for info in info.constant_buffers.iter() {
+                if let Some(res) = meta_cbuf.link_constant_buffer(info, cbuf) {
+                    // println!("Linked {:?}", res);
+                    let d = res.map_err(|e| InitError::ConstantBuffer(info.name.as_str(), Some(e)))?;
+                    meta.const_bufs.push(meta_cbuf);
+                    desc.constant_buffers[info.slot as usize] = Some(d);
+                    break;
+                }
             }
         }
 
-        for (info, global) in info.globals.iter().zip(&self.globals) {
+        for global in self.globals.iter() {
             // println!("Link global {:?}/{:?}", info.name, global);
             let mut meta_global = <RawGlobal as DataLink<'d>>::new();
-            if let Some(res) = meta_global.link_global_constant(info, global) {
-                // println!("Linked {:?}", res);
-                res.map_err(|e| InitError::GlobalConstant(info.name.as_str(), Some(e)))?;
-                meta.globals.push(meta_global);
+            for info in info.globals.iter() {
+                if let Some(res) = meta_global.link_global_constant(info, global) {
+                    // println!("Linked {:?}", res);
+                    res.map_err(|e| InitError::GlobalConstant(info.name.as_str(), Some(e)))?;
+                    meta.globals.push(meta_global);
+                    break;
+                }
             }
         }
 
-        for (info, color) in info.outputs.iter().zip(&self.out_colors) {
+        for color in self.out_colors.iter() {
             let mut meta_color = <RenderTarget as DataLink<'d>>::new();
-            if let Some(res) = meta_color.link_output(info, color) {
-                let d = res.map_err(|e| InitError::PixelExport(info.name.as_str(), Some(e)))?;
-                meta.out_colors.push(meta_color);
-                desc.color_targets[info.slot as usize] = Some(d);
+            for info in info.outputs.iter() {
+                if let Some(res) = meta_color.link_output(info, color) {
+                    let d = res.map_err(|e| InitError::PixelExport(info.name.as_str(), Some(e)))?;
+                    meta.out_colors.push(meta_color);
+                    desc.color_targets[info.slot as usize] = Some(d);
+                    break;
+                }
             }
         }
         if !info.knows_outputs {
@@ -97,24 +106,32 @@ impl<'d> PipelineInit for Init<'d> {
             }
         }
 
-        for (info, smp) in info.samplers.iter().zip(&self.samplers) {
+        for smp in self.samplers.iter() {
             // println!("Link sampler {:?}/{:?}", info, smp);
             let mut meta_smp = <Sampler as DataLink<'d>>::new();
-            if let Some(d) = meta_smp.link_sampler(info, smp) {
-                // println!("Linked {:?}", d);
-                meta.samplers.push(meta_smp);
-                desc.samplers[info.slot as usize] = Some(d);
+
+            for info in info.samplers.iter() {
+                if let Some(d) = meta_smp.link_sampler(info, smp) {
+                    // println!("Linked {:?}", d);
+                    meta.samplers.push(meta_smp);
+                    desc.samplers[info.slot as usize] = Some(d);
+                    break;
+                }
             }
         }
 
-        for (info, tex) in info.textures.iter().zip(&self.textures) {
+        for tex in self.textures.iter() {
             // println!("Link texture {:?}/{:?}", info, tex);
             let mut meta_tex = <RawShaderResource as DataLink<'d>>::new();
-            if let Some(res) = meta_tex.link_resource_view(info, tex) {
-                // println!("Linked {:?}", res);
-                let d = res.map_err(|_| InitError::ResourceView(info.name.as_str(), Some(())))?;
-                meta.textures.push(meta_tex);
-                desc.resource_views[info.slot as usize] = Some(d);
+
+            for info in info.textures.iter() {
+                if let Some(res) = meta_tex.link_resource_view(info, tex) {
+                    // println!("Linked {:?}", res);
+                    let d = res.map_err(|_| InitError::ResourceView(info.name.as_str(), Some(())))?;
+                    meta.textures.push(meta_tex);
+                    desc.resource_views[info.slot as usize] = Some(d);
+                    break;
+                }
             }
         }
 

--- a/amethyst_renderer/src/pipe/effect/pso.rs
+++ b/amethyst_renderer/src/pipe/effect/pso.rs
@@ -42,42 +42,43 @@ impl<'d> PipelineInit for Init<'d> {
         let mut meta = Meta::default();
 
         for cbuf in self.const_bufs.iter() {
-            // println!("Link constant {:?}/{:?}", info.name, cbuf);
             let mut meta_cbuf = <RawConstantBuffer as DataLink<'d>>::new();
             for info in info.constant_buffers.iter() {
+                // println!("Link constant {:?}/{:?}", info.name, cbuf);
                 if let Some(res) = meta_cbuf.link_constant_buffer(info, cbuf) {
                     // println!("Linked {:?}", res);
                     let d = res.map_err(|e| InitError::ConstantBuffer(info.name.as_str(), Some(e)))?;
-                    meta.const_bufs.push(meta_cbuf);
                     desc.constant_buffers[info.slot as usize] = Some(d);
                     break;
                 }
             }
+            meta.const_bufs.push(meta_cbuf);
         }
 
         for global in self.globals.iter() {
-            // println!("Link global {:?}/{:?}", info.name, global);
             let mut meta_global = <RawGlobal as DataLink<'d>>::new();
             for info in info.globals.iter() {
+                // println!("Link global {:?}/{:?}", info.name, global);
                 if let Some(res) = meta_global.link_global_constant(info, global) {
                     // println!("Linked {:?}", res);
                     res.map_err(|e| InitError::GlobalConstant(info.name.as_str(), Some(e)))?;
-                    meta.globals.push(meta_global);
                     break;
                 }
             }
+            meta.globals.push(meta_global);
         }
 
         for color in self.out_colors.iter() {
             let mut meta_color = <RenderTarget as DataLink<'d>>::new();
             for info in info.outputs.iter() {
+                // println!("Link output {:?}/{:?}", info.name, color);
                 if let Some(res) = meta_color.link_output(info, color) {
                     let d = res.map_err(|e| InitError::PixelExport(info.name.as_str(), Some(e)))?;
-                    meta.out_colors.push(meta_color);
                     desc.color_targets[info.slot as usize] = Some(d);
                     break;
                 }
             }
+            meta.out_colors.push(meta_color);
         }
         if !info.knows_outputs {
             let mut info = OutputVar {
@@ -87,52 +88,52 @@ impl<'d> PipelineInit for Init<'d> {
                 container: ContainerType::Vector(4),
             };
             for color in self.out_colors.iter() {
+                // println!("Link unknown output {:?}/{:?}", info.name, color);
                 let mut meta_color = <RenderTarget as DataLink<'d>>::new();
                 if let Some(res) = meta_color.link_output(&info, color) {
                     let d = res.map_err(|e| InitError::PixelExport("", Some(e)))?;
-                    meta.out_colors.push(meta_color);
                     desc.color_targets[info.slot as usize] = Some(d);
                     info.slot += 1;
                 }
+                meta.out_colors.push(meta_color);
             }
         }
 
         if let Some(depth) = self.out_depth {
             let mut meta_depth = <DepthStencilTarget as DataLink<'d>>::new();
+            // println!("Link depth {:?}", depth);
             if let Some(d) = meta_depth.link_depth_stencil(&depth) {
                 desc.scissor = meta_depth.link_scissor();
-                meta.out_depth = Some(meta_depth);
                 desc.depth_stencil = Some(d);
             }
+            meta.out_depth = Some(meta_depth);
         }
 
         for smp in self.samplers.iter() {
-            // println!("Link sampler {:?}/{:?}", info, smp);
             let mut meta_smp = <Sampler as DataLink<'d>>::new();
-
             for info in info.samplers.iter() {
+                // println!("Link sampler {:?}/{:?}", info, smp);
                 if let Some(d) = meta_smp.link_sampler(info, smp) {
                     // println!("Linked {:?}", d);
-                    meta.samplers.push(meta_smp);
                     desc.samplers[info.slot as usize] = Some(d);
                     break;
                 }
             }
+            meta.samplers.push(meta_smp);
         }
 
         for tex in self.textures.iter() {
-            // println!("Link texture {:?}/{:?}", info, tex);
             let mut meta_tex = <RawShaderResource as DataLink<'d>>::new();
-
             for info in info.textures.iter() {
+                // println!("Link texture {:?}/{:?}", info, tex);
                 if let Some(res) = meta_tex.link_resource_view(info, tex) {
                     // println!("Linked {:?}", res);
                     let d = res.map_err(|_| InitError::ResourceView(info.name.as_str(), Some(())))?;
-                    meta.textures.push(meta_tex);
                     desc.resource_views[info.slot as usize] = Some(d);
                     break;
                 }
             }
+            meta.textures.push(meta_tex);
         }
 
         for (i, vbuf) in self.vertex_bufs.iter().enumerate() {
@@ -144,10 +145,9 @@ impl<'d> PipelineInit for Init<'d> {
                         desc.attributes[attr.slot as usize] = Some(d);
                     }
                 }
-
-                meta.vertex_bufs.push(meta_vbuf);
                 desc.vertex_buffers[i] = Some(d);
             }
+            meta.vertex_bufs.push(meta_vbuf);
         }
 
         Ok(meta)

--- a/amethyst_renderer/src/pipe/effect/pso.rs
+++ b/amethyst_renderer/src/pipe/effect/pso.rs
@@ -42,8 +42,10 @@ impl<'d> PipelineInit for Init<'d> {
         let mut meta = Meta::default();
 
         for (info, cbuf) in info.constant_buffers.iter().zip(&self.const_bufs) {
+            // println!("Link constant {:?}/{:?}", info.name, cbuf);
             let mut meta_cbuf = <RawConstantBuffer as DataLink<'d>>::new();
             if let Some(res) = meta_cbuf.link_constant_buffer(info, cbuf) {
+                // println!("Linked {:?}", res);
                 let d = res.map_err(|e| InitError::ConstantBuffer(info.name.as_str(), Some(e)))?;
                 meta.const_bufs.push(meta_cbuf);
                 desc.constant_buffers[info.slot as usize] = Some(d);
@@ -51,8 +53,10 @@ impl<'d> PipelineInit for Init<'d> {
         }
 
         for (info, global) in info.globals.iter().zip(&self.globals) {
+            // println!("Link global {:?}/{:?}", info.name, global);
             let mut meta_global = <RawGlobal as DataLink<'d>>::new();
             if let Some(res) = meta_global.link_global_constant(info, global) {
+                // println!("Linked {:?}", res);
                 res.map_err(|e| InitError::GlobalConstant(info.name.as_str(), Some(e)))?;
                 meta.globals.push(meta_global);
             }
@@ -94,16 +98,20 @@ impl<'d> PipelineInit for Init<'d> {
         }
 
         for (info, smp) in info.samplers.iter().zip(&self.samplers) {
+            // println!("Link sampler {:?}/{:?}", info, smp);
             let mut meta_smp = <Sampler as DataLink<'d>>::new();
             if let Some(d) = meta_smp.link_sampler(info, smp) {
+                // println!("Linked {:?}", d);
                 meta.samplers.push(meta_smp);
                 desc.samplers[info.slot as usize] = Some(d);
             }
         }
 
         for (info, tex) in info.textures.iter().zip(&self.textures) {
+            // println!("Link texture {:?}/{:?}", info, tex);
             let mut meta_tex = <RawShaderResource as DataLink<'d>>::new();
             if let Some(res) = meta_tex.link_resource_view(info, tex) {
+                // println!("Linked {:?}", res);
                 let d = res.map_err(|_| InitError::ResourceView(info.name.as_str(), Some(())))?;
                 meta.textures.push(meta_tex);
                 desc.resource_views[info.slot as usize] = Some(d);

--- a/amethyst_renderer/src/pipe/effect/pso.rs
+++ b/amethyst_renderer/src/pipe/effect/pso.rs
@@ -44,9 +44,7 @@ impl<'d> PipelineInit for Init<'d> {
         for cbuf in self.const_bufs.iter() {
             let mut meta_cbuf = <RawConstantBuffer as DataLink<'d>>::new();
             for info in info.constant_buffers.iter() {
-                // println!("Link constant {:?}/{:?}", info.name, cbuf);
                 if let Some(res) = meta_cbuf.link_constant_buffer(info, cbuf) {
-                    // println!("Linked {:?}", res);
                     let d = res.map_err(|e| InitError::ConstantBuffer(info.name.as_str(), Some(e)))?;
                     desc.constant_buffers[info.slot as usize] = Some(d);
                     break;
@@ -58,9 +56,7 @@ impl<'d> PipelineInit for Init<'d> {
         for global in self.globals.iter() {
             let mut meta_global = <RawGlobal as DataLink<'d>>::new();
             for info in info.globals.iter() {
-                // println!("Link global {:?}/{:?}", info.name, global);
                 if let Some(res) = meta_global.link_global_constant(info, global) {
-                    // println!("Linked {:?}", res);
                     res.map_err(|e| InitError::GlobalConstant(info.name.as_str(), Some(e)))?;
                     break;
                 }
@@ -71,7 +67,6 @@ impl<'d> PipelineInit for Init<'d> {
         for color in self.out_colors.iter() {
             let mut meta_color = <RenderTarget as DataLink<'d>>::new();
             for info in info.outputs.iter() {
-                // println!("Link output {:?}/{:?}", info.name, color);
                 if let Some(res) = meta_color.link_output(info, color) {
                     let d = res.map_err(|e| InitError::PixelExport(info.name.as_str(), Some(e)))?;
                     desc.color_targets[info.slot as usize] = Some(d);
@@ -88,7 +83,6 @@ impl<'d> PipelineInit for Init<'d> {
                 container: ContainerType::Vector(4),
             };
             for color in self.out_colors.iter() {
-                // println!("Link unknown output {:?}/{:?}", info.name, color);
                 let mut meta_color = <RenderTarget as DataLink<'d>>::new();
                 if let Some(res) = meta_color.link_output(&info, color) {
                     let d = res.map_err(|e| InitError::PixelExport("", Some(e)))?;
@@ -101,7 +95,6 @@ impl<'d> PipelineInit for Init<'d> {
 
         if let Some(depth) = self.out_depth {
             let mut meta_depth = <DepthStencilTarget as DataLink<'d>>::new();
-            // println!("Link depth {:?}", depth);
             if let Some(d) = meta_depth.link_depth_stencil(&depth) {
                 desc.scissor = meta_depth.link_scissor();
                 desc.depth_stencil = Some(d);
@@ -112,9 +105,7 @@ impl<'d> PipelineInit for Init<'d> {
         for smp in self.samplers.iter() {
             let mut meta_smp = <Sampler as DataLink<'d>>::new();
             for info in info.samplers.iter() {
-                // println!("Link sampler {:?}/{:?}", info, smp);
                 if let Some(d) = meta_smp.link_sampler(info, smp) {
-                    // println!("Linked {:?}", d);
                     desc.samplers[info.slot as usize] = Some(d);
                     break;
                 }
@@ -125,9 +116,7 @@ impl<'d> PipelineInit for Init<'d> {
         for tex in self.textures.iter() {
             let mut meta_tex = <RawShaderResource as DataLink<'d>>::new();
             for info in info.textures.iter() {
-                // println!("Link texture {:?}/{:?}", info, tex);
                 if let Some(res) = meta_tex.link_resource_view(info, tex) {
-                    // println!("Linked {:?}", res);
                     let d = res.map_err(|_| InitError::ResourceView(info.name.as_str(), Some(())))?;
                     desc.resource_views[info.slot as usize] = Some(d);
                     break;

--- a/amethyst_renderer/src/pipe/mod.rs
+++ b/amethyst_renderer/src/pipe/mod.rs
@@ -16,7 +16,7 @@
 //!     .expect("Could not build pipeline");
 //! ```
 
-pub use self::effect::{Effect, EffectBuilder};
+pub use self::effect::{Effect, EffectBuilder, DepthMode};
 pub use self::stage::{Stage, StageBuilder};
 pub use self::target::{ColorBuffer, DepthBuffer, Target, TargetBuilder, Targets};
 
@@ -41,14 +41,14 @@ pub struct Pipeline {
 
 impl Pipeline {
     /// Builds a new renderer pipeline.
-    pub fn build() -> PipelineBuilder {
+    pub fn build<'a>() -> PipelineBuilder<'a> {
         PipelineBuilder::new()
     }
 
     /// Builds a default deferred pipeline.
     ///
     /// FIXME: Only generates a dummy pipeline for now.
-    pub fn deferred() -> PipelineBuilder {
+    pub fn deferred<'a>() -> PipelineBuilder<'a> {
         use pass::*;
         PipelineBuilder::new()
             .with_target(Target::named("gbuffer")
@@ -63,7 +63,7 @@ impl Pipeline {
     /// Builds a default forward pipeline.
     ///
     /// FIXME: Only generates a dummy pipeline for now.
-    pub fn forward() -> PipelineBuilder {
+    pub fn forward<'a>() -> PipelineBuilder<'a> {
         use pass::*;
         PipelineBuilder::new()
             .with_stage(Stage::with_backbuffer()
@@ -83,14 +83,14 @@ impl Pipeline {
 
 /// Constructs a new pipeline with the given render targets and layers.
 #[derive(Clone, Debug)]
-pub struct PipelineBuilder {
-    stages: Vec<StageBuilder>,
+pub struct PipelineBuilder<'a> {
+    stages: Vec<StageBuilder<'a>>,
     targets: Vec<TargetBuilder>,
 }
 
-impl PipelineBuilder {
+impl<'a> PipelineBuilder<'a> {
     /// Creates a new PipelineBuilder.
-    pub fn new() -> PipelineBuilder {
+    pub fn new() -> Self {
         PipelineBuilder {
             stages: Vec::new(),
             targets: Vec::new(),
@@ -104,7 +104,7 @@ impl PipelineBuilder {
     }
 
     /// Constructs a new stage in this pipeline.
-    pub fn with_stage(mut self, sb: StageBuilder) -> Self {
+    pub fn with_stage(mut self, sb: StageBuilder<'a>) -> Self {
         self.stages.push(sb);
         self
     }

--- a/amethyst_renderer/src/pipe/pass.rs
+++ b/amethyst_renderer/src/pipe/pass.rs
@@ -10,12 +10,14 @@ use std::sync::Arc;
 use types::{Encoder, Factory};
 
 pub type FunctionFn = Arc<Fn(&mut Encoder, &Target) + Send + Sync>;
+pub type MainFn = Arc<Fn(&mut Encoder, &Target, &Model, &Effect, &Scene) + Send + Sync>;
 pub type PostFn = Arc<Fn(&mut Encoder, &Target, &Effect, &Scene) + Send + Sync>;
 
 /// Discrete rendering pass.
 #[derive(Clone)]
 pub enum Pass {
     Function(FunctionFn),
+    Main(MainFn, Effect),
     Post(PostFn, Effect),
 }
 
@@ -24,6 +26,7 @@ impl Pass {
     pub fn apply(&self, enc: &mut Encoder, model: &Model, scene: &Scene, out: &Target) {
         match *self {
             Pass::Function(ref func) => func(enc, out),
+            Pass::Main(ref func, ref e) => func(enc, out, model, e, scene),
             Pass::Post(ref func, ref e) => func(enc, out, e, scene),
         }
     }
@@ -37,6 +40,12 @@ impl Debug for Pass {
                     .field(&"[closure]")
                     .finish()
             }
+            Pass::Main(_, ref e) => {
+                fmt.debug_tuple("Main")
+                    .field(&"[closure]")
+                    .field(e)
+                    .finish()
+            }
             Pass::Post(_, ref e) => {
                 fmt.debug_tuple("Post")
                     .field(&"[closure]")
@@ -48,19 +57,25 @@ impl Debug for Pass {
 }
 
 #[derive(Clone)]
-pub enum PassBuilder {
+pub enum PassBuilder<'a> {
     Function(FunctionFn),
-    Post(PostFn, EffectBuilder),
+    Main(MainFn, EffectBuilder<'a>),
+    Post(PostFn, EffectBuilder<'a>),
 }
 
-impl PassBuilder {
-    pub fn function<F>(func: F) -> PassBuilder
+impl<'a> PassBuilder<'a> {
+    pub fn function<F>(func: F) -> Self
         where F: Fn(&mut Encoder, &Target) + Send + Sync + 'static
     {
         PassBuilder::Function(Arc::new(func))
     }
+    pub fn main<F>(eb: EffectBuilder<'a>, func: F) -> Self
+        where F: Fn(&mut Encoder, &Target, &Model, &Effect, &Scene) + Send + Sync + 'static
+    {
+        PassBuilder::Main(Arc::new(func), eb)
+    }
 
-    pub fn postproc<F>(eb: EffectBuilder, func: F) -> PassBuilder
+    pub fn postproc<F>(eb: EffectBuilder<'a>, func: F) -> Self
         where F: Fn(&mut Encoder, &Target, &Effect, &Scene) + Send + Sync + 'static
     {
         PassBuilder::Post(Arc::new(func), eb)
@@ -69,17 +84,24 @@ impl PassBuilder {
     pub(crate) fn finish(self, fac: &mut Factory, t: &Targets, out: &Target) -> Result<Pass> {
         match self {
             PassBuilder::Function(f) => Ok(Pass::Function(f)),
+            PassBuilder::Main(f, e) => Ok(Pass::Main(f, e.finish(fac, out)?)),
             PassBuilder::Post(f, e) => Ok(Pass::Post(f, e.finish(fac, out)?)),
         }
     }
 }
 
-impl Debug for PassBuilder {
+impl<'a> Debug for PassBuilder<'a> {
     fn fmt(&self, fmt: &mut Formatter) -> FmtResult {
         match *self {
             PassBuilder::Function(_) => {
                 fmt.debug_tuple("Function")
                     .field(&"[closure]")
+                    .finish()
+            }
+            PassBuilder::Main(_, ref e) => {
+                fmt.debug_tuple("Main")
+                    .field(&"[closure]")
+                    .field(e)
                     .finish()
             }
             PassBuilder::Post(_, ref e) => {

--- a/amethyst_renderer/src/pipe/stage.rs
+++ b/amethyst_renderer/src/pipe/stage.rs
@@ -17,12 +17,12 @@ pub struct Stage {
 
 impl Stage {
     /// Creates a new stage using the Target with the given name.
-    pub fn with_target<T: Into<String>>(target_name: T) -> StageBuilder {
+    pub fn with_target<'a, T: Into<String>>(target_name: T) -> StageBuilder<'a> {
         StageBuilder::new(target_name.into())
     }
 
     /// Creates a new layer which draws straight into the backbuffer.
-    pub fn with_backbuffer() -> StageBuilder {
+    pub fn with_backbuffer<'a>() -> StageBuilder<'a> {
         StageBuilder::new("")
     }
 
@@ -49,13 +49,13 @@ impl Stage {
 
 /// Constructs a new rendering stage.
 #[derive(Clone, Debug)]
-pub struct StageBuilder {
+pub struct StageBuilder<'a> {
     enabled: bool,
-    passes: Vec<PassBuilder>,
+    passes: Vec<PassBuilder<'a>>,
     target_name: String,
 }
 
-impl StageBuilder {
+impl<'a> StageBuilder<'a> {
     /// Creates a new `StageBuilder` using the given target.
     pub fn new<T: Into<String>>(target_name: T) -> Self {
         StageBuilder {
@@ -66,7 +66,7 @@ impl StageBuilder {
     }
 
     /// Appends another `Pass` to the stage.
-    pub fn with_pass<P: Into<PassBuilder>>(mut self, pass: P) -> Self {
+    pub fn with_pass<P: Into<PassBuilder<'a>>>(mut self, pass: P) -> Self {
         self.passes.push(pass.into());
         self
     }

--- a/amethyst_renderer/src/prelude.rs
+++ b/amethyst_renderer/src/prelude.rs
@@ -1,8 +1,11 @@
 //! Contains common types that can be glob-imported (`*`) for convenience.
 
 pub use Renderer;
+pub use cam::{Camera, Projection};
 pub use light::*;
 pub use mesh::{Mesh, MeshBuilder};
+pub use mtl::{Material, MaterialBuilder};
 pub use pipe::{Pipeline, PipelineBuilder, Stage, StageBuilder, Target};
-pub use scene::Scene;
+pub use scene::{Model, Scene};
 pub use tex::{Texture, TextureBuilder};
+pub use pass;

--- a/amethyst_renderer/src/scene.rs
+++ b/amethyst_renderer/src/scene.rs
@@ -21,8 +21,12 @@ pub type Lights<'l> = Iter<'l, Light>;
 
 /// Immutable parallel iterator of models.
 pub type Models<'l> = Iter<'l, Model>;
+
 /// Immutable parallel iterator of models.
 pub type ModelsChunks<'l> = Chunks<'l, Model>;
+
+/// Immutable parallel iterator of models.
+pub type LightsChunks<'l> = Chunks<'l, Light>;
 
 /// Collection of lights and meshes to render.
 #[derive(Clone, Debug, Default, PartialEq)]
@@ -57,6 +61,13 @@ impl Scene {
     pub fn par_iter_lights(&self) -> Lights {
         use rayon::prelude::*;
         self.lights.par_iter()
+    }
+
+    /// Iterates through all stored lights in parallel in chunks.
+    pub fn par_chunks_lights(&self, count: usize) -> LightsChunks {
+        use rayon::prelude::*;
+        let size = self.lights.len();
+        self.lights.par_chunks(((size - 1) / count) + 1)
     }
 
     /// Iterates through all stored models in parallel.

--- a/amethyst_renderer/src/scene.rs
+++ b/amethyst_renderer/src/scene.rs
@@ -48,6 +48,11 @@ impl Scene {
         self.cameras.push(camera.into());
     }
 
+    /// Get all lights on scene
+    pub fn lights(&self) -> &[Light] {
+        &self.lights
+    }
+
     /// Iterates through all stored lights in parallel.
     pub fn par_iter_lights(&self) -> Lights {
         use rayon::prelude::*;

--- a/amethyst_renderer/src/tex.rs
+++ b/amethyst_renderer/src/tex.rs
@@ -26,6 +26,11 @@ impl Texture {
     pub fn from_color_val<C: Into<[f32; 4]>>(rgba: C) -> TextureBuilder {
         TextureBuilder::from_color_val(rgba)
     }
+
+    /// Get view
+    pub fn view(&self) -> &RawShaderResourceView {
+        &self.view
+    }
 }
 
 /// Builds new textures.
@@ -41,7 +46,7 @@ impl TextureBuilder {
         where T: Copy + Pod,
               D: Into<&'d [T]>
     {
-        use gfx::Bind;
+        use gfx::{SHADER_RESOURCE, Bind};
         use gfx::format::SurfaceType;
         use gfx::memory::{Usage, cast_slice};
         use gfx::texture::{AaMode, Kind};
@@ -52,7 +57,7 @@ impl TextureBuilder {
                 kind: Kind::D2(1, 1, AaMode::Single),
                 levels: 1,
                 format: SurfaceType::R8_G8_B8_A8,
-                bind: Bind::empty(),
+                bind: SHADER_RESOURCE,
                 usage: Usage::Dynamic,
             },
         }
@@ -97,7 +102,7 @@ impl TextureBuilder {
         use gfx::texture::ResourceDesc;
 
         let chan = ChannelType::Srgb;
-        let tex = fac.create_texture_raw(self.info, Some(chan), None)?;
+        let tex = fac.create_texture_raw(self.info, Some(chan), Some(&[self.data.as_slice()]))?;
 
         let desc = ResourceDesc {
             channel: ChannelType::Srgb,

--- a/amethyst_renderer/src/tex.rs
+++ b/amethyst_renderer/src/tex.rs
@@ -15,9 +15,9 @@ pub struct Texture {
 
 impl Texture {
     /// Builds a new texture with the given raw texture data.
-    pub fn build<'d, T: 'd, D>(data: D) -> TextureBuilder
+    pub fn build<T, D>(data: D) -> TextureBuilder
         where T: Copy + Pod,
-              D: Into<&'d [T]>
+              D: AsRef<[T]>
     {
         TextureBuilder::new(data)
     }
@@ -42,9 +42,9 @@ pub struct TextureBuilder {
 
 impl TextureBuilder {
     /// Creates a new `TextureBuilder` with the given raw texture data.
-    pub fn new<'d, T: 'd, D>(data: D) -> TextureBuilder
+    pub fn new<T, D>(data: D) -> TextureBuilder
         where T: Copy + Pod,
-              D: Into<&'d [T]>
+              D: AsRef<[T]>
     {
         use gfx::{SHADER_RESOURCE, Bind};
         use gfx::format::SurfaceType;
@@ -52,7 +52,7 @@ impl TextureBuilder {
         use gfx::texture::{AaMode, Kind};
 
         TextureBuilder {
-            data: cast_slice(data.into()).to_vec(),
+            data: cast_slice(data.as_ref()).to_vec(),
             info: Info {
                 kind: Kind::D2(1, 1, AaMode::Single),
                 levels: 1,

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -46,10 +46,23 @@ pub trait VertexFormat: Pod + Structure<Format> + Sized {
     fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes;
 
     /// Returns the size of a single vertex in bytes.
+    #[inline]
     fn size() -> usize {
         use std::mem;
         mem::size_of::<Self>()
     }
+
+    /// Returns attribute of vertex by type
+    #[inline]
+    fn attribute<F>() -> Attribute where Self: WithField<F> {
+        <Self as WithField<F>>::field_attribute()
+    }
+}
+
+/// Trait implemented by all valid vertex formats for each field
+pub trait WithField<F>: VertexFormat {
+    /// Query individual attribute of the field for this format
+    fn field_attribute() -> Attribute;
 }
 
 /// Vertex format with position and RGBA8 color attributes.
@@ -74,6 +87,19 @@ impl VertexFormat for PosColor {
     }
 }
 
+impl WithField<Position> for PosColor {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_position").unwrap()
+    }
+}
+
+impl WithField<Color> for PosColor {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_color").unwrap()
+    }
+}
 
 /// Vertex format with position and UV texture coordinate attributes.
 #[derive(Clone, Copy, Debug, PartialEq, VertexData)]
@@ -94,6 +120,20 @@ impl VertexFormat for PosTex {
     #[inline]
     fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
         [(N::name::<Position>(), Self::query("a_position").unwrap()), (N::name::<TextureCoord>(), Self::query("a_tex_coord").unwrap())]
+    }
+}
+
+impl WithField<Position> for PosTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_position").unwrap()
+    }
+}
+
+impl WithField<TextureCoord> for PosTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_tex_coord").unwrap()
     }
 }
 
@@ -121,6 +161,27 @@ impl VertexFormat for PosNormTex {
     }
 }
 
+impl WithField<Position> for PosNormTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_position").unwrap()
+    }
+}
+
+impl WithField<Normal> for PosNormTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_normal").unwrap()
+    }
+}
+
+impl WithField<TextureCoord> for PosNormTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_tex_coord").unwrap()
+    }
+}
+
 /// Vertex format with position, normal, and UV texture coordinate attributes.
 #[derive(Clone, Copy, Debug, PartialEq, VertexData)]
 pub struct PosNormTangTex {
@@ -144,5 +205,33 @@ impl VertexFormat for PosNormTangTex {
     #[inline]
     fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
         [(N::name::<Position>(), Self::query("a_position").unwrap()), (N::name::<Normal>(), Self::query("a_normal").unwrap()), (N::name::<Tangent>(), Self::query("a_tangent").unwrap()), (N::name::<TextureCoord>(), Self::query("a_tex_coord").unwrap())]
+    }
+}
+
+impl WithField<Position> for PosNormTangTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_position").unwrap()
+    }
+}
+
+impl WithField<Normal> for PosNormTangTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_normal").unwrap()
+    }
+}
+
+impl WithField<Tangent> for PosNormTangTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_tangent").unwrap()
+    }
+}
+
+impl WithField<TextureCoord> for PosNormTangTex {
+    #[inline]
+    fn field_attribute() -> Attribute {
+        Self::query("a_tex_coord").unwrap()
     }
 }

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -21,7 +21,7 @@ pub enum TextureCoord {}
 /// Type for texture coord attribute of vertex
 pub enum Normal {}
 
-/// Type for tangent attribute of vertes
+/// Type for tangent attribute of vertex
 pub enum Tangent {}
 
 /// Trait for mapping attribute type -> name
@@ -118,5 +118,31 @@ impl VertexFormat for PosNormTex {
     #[inline]
     fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
         [(N::name::<Position>(), Self::query("a_position").unwrap()), (N::name::<Normal>(), Self::query("a_normal").unwrap()), (N::name::<TextureCoord>(), Self::query("a_tex_coord").unwrap())]
+    }
+}
+
+/// Vertex format with position, normal, and UV texture coordinate attributes.
+#[derive(Clone, Copy, Debug, PartialEq, VertexData)]
+pub struct PosNormTangTex {
+    /// Position of the vertex in 3D space.
+    pub a_position: [f32; 3],
+    /// Normal vector of the vertex.
+    pub a_normal: [f32; 3],
+    /// Tangent vector of the vertex.
+    pub a_tangent: [f32; 3],
+    /// UV texture coordinates used by the vertex.
+    pub a_tex_coord: [f32; 2],
+}
+
+impl VertexFormat for PosNormTangTex {
+    type Attributes = [Attribute; 4];
+    type NamedAttributes = [(&'static str, Attribute); 4];
+    #[inline]
+    fn attributes() -> Self::Attributes {
+        [Self::query("a_position").unwrap(), Self::query("a_normal").unwrap(), Self::query("a_tangent").unwrap(), Self::query("a_tex_coord").unwrap()]
+    }
+    #[inline]
+    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
+        [(N::name::<Position>(), Self::query("a_position").unwrap()), (N::name::<Normal>(), Self::query("a_normal").unwrap()), (N::name::<Tangent>(), Self::query("a_tangent").unwrap()), (N::name::<TextureCoord>(), Self::query("a_tex_coord").unwrap())]
     }
 }

--- a/amethyst_renderer/src/vertex.rs
+++ b/amethyst_renderer/src/vertex.rs
@@ -4,14 +4,47 @@ use gfx;
 use gfx::format::Format;
 use gfx::pso::buffer::Structure;
 use gfx::traits::Pod;
+use std::any::Any;
 
 /// Handle to a vertex attribute.
 pub type Attribute = gfx::pso::buffer::Element<Format>;
 
+/// Type for position attribute of vertex
+pub enum Position {}
+
+/// Type for color attribute of vertex
+pub enum Color {}
+
+/// Type for texture coord attribute of vertex
+pub enum TextureCoord {}
+
+/// Type for texture coord attribute of vertex
+pub enum Normal {}
+
+/// Type for tangent attribute of vertes
+pub enum Tangent {}
+
+/// Trait for mapping attribute type -> name
+pub trait AttributeNames {
+    /// Get name for specified attribute type
+    fn name<A: Any>() -> &'static str;
+}
+
 /// Trait implemented by all valid vertex formats.
 pub trait VertexFormat: Pod + Structure<Format> + Sized {
+    /// Container for attributes of this format
+    type Attributes: AsRef<[Attribute]>;
+
+    /// Container for name+attribute pairs of this format
+    type NamedAttributes: AsRef<[(&'static str, Attribute)]>;
+
     /// Returns a list of all attributes specified in the vertex.
-    fn attributes() -> Vec<Attribute>;
+    fn attributes() -> Self::Attributes;
+
+    /// Returns a list of all name+attribute pairs specified in the vertex.
+    /// The caller provides attribute type -> Name mapping
+    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes;
+
     /// Returns the size of a single vertex in bytes.
     fn size() -> usize {
         use std::mem;
@@ -29,12 +62,18 @@ pub struct PosColor {
 }
 
 impl VertexFormat for PosColor {
+    type Attributes = [Attribute; 2];
+    type NamedAttributes = [(&'static str, Attribute); 2];
     #[inline]
-    fn attributes() -> Vec<Attribute> {
-        vec![Self::query("a_position").unwrap(),
-             Self::query("a_color").unwrap()]
+    fn attributes() -> Self::Attributes {
+        [Self::query("a_position").unwrap(), Self::query("a_color").unwrap()]
+    }
+    #[inline]
+    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
+        [(N::name::<Position>(), Self::query("a_position").unwrap()), (N::name::<Color>(), Self::query("a_color").unwrap())]
     }
 }
+
 
 /// Vertex format with position and UV texture coordinate attributes.
 #[derive(Clone, Copy, Debug, PartialEq, VertexData)]
@@ -46,10 +85,15 @@ pub struct PosTex {
 }
 
 impl VertexFormat for PosTex {
+    type Attributes = [Attribute; 2];
+    type NamedAttributes = [(&'static str, Attribute); 2];
     #[inline]
-    fn attributes() -> Vec<Attribute> {
-        vec![Self::query("a_position").unwrap(),
-             Self::query("a_tex_coord").unwrap()]
+    fn attributes() -> Self::Attributes {
+        [Self::query("a_position").unwrap(), Self::query("a_tex_coord").unwrap()]
+    }
+    #[inline]
+    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
+        [(N::name::<Position>(), Self::query("a_position").unwrap()), (N::name::<TextureCoord>(), Self::query("a_tex_coord").unwrap())]
     }
 }
 
@@ -59,16 +103,20 @@ pub struct PosNormTex {
     /// Position of the vertex in 3D space.
     pub a_position: [f32; 3],
     /// Normal vector of the vertex.
-    pub a_normal: [f32; 4],
+    pub a_normal: [f32; 3],
     /// UV texture coordinates used by the vertex.
     pub a_tex_coord: [f32; 2],
 }
 
 impl VertexFormat for PosNormTex {
+    type Attributes = [Attribute; 3];
+    type NamedAttributes = [(&'static str, Attribute); 3];
     #[inline]
-    fn attributes() -> Vec<Attribute> {
-        vec![Self::query("a_position").unwrap(),
-             Self::query("a_normal").unwrap(),
-             Self::query("a_tex_coord").unwrap()]
+    fn attributes() -> Self::Attributes {
+        [Self::query("a_position").unwrap(), Self::query("a_normal").unwrap(), Self::query("a_tex_coord").unwrap()]
+    }
+    #[inline]
+    fn named_attributes<N: AttributeNames>() -> Self::NamedAttributes {
+        [(N::name::<Position>(), Self::query("a_position").unwrap()), (N::name::<Normal>(), Self::query("a_normal").unwrap()), (N::name::<TextureCoord>(), Self::query("a_tex_coord").unwrap())]
     }
 }


### PR DESCRIPTION
- Tweak `VertexFormat` trait. Adding an ability to identify kind of data an attribute belongs
- Add missing stuff to `EffectBuilder`
- Link unknown outputs in `effect::pso::Link`
- Add `Pass` variant with function that receives models
- Slice models into chunks and feed 'em to encoders
    Old mechanism draw only first `encoders.len()` models
- Add `DrawFlat` pass
- Fix issue with black textures
    by actually passing texture data on texture object creation
- Modify sphere example to render flat sphere using `DrawFlat` pass